### PR TITLE
Update Supabase cookbook README wording

### DIFF
--- a/typescript-recipes/parallel-supabase-enrichment/README.md
+++ b/typescript-recipes/parallel-supabase-enrichment/README.md
@@ -1,8 +1,8 @@
 # Data Enrichment with Supabase + Parallel
 
-Build a real-time data enrichment pipeline using [Supabase Edge Functions](https://supabase.com/docs/guides/functions) and [Parallel's Task API](https://docs.parallel.ai/task-api/task-quickstart).
+Enrich your Supabase data with live web intelligence using [Supabase Edge Functions](https://supabase.com/docs/guides/functions) and [Parallel's Task API](https://docs.parallel.ai/task-api/task-quickstart).
 
-This cookbook demonstrates how to create a data enrichment experience where users input minimal data (e.g., company names) and get back enriched information automatically.
+This cookbook demonstrates how to build a data enrichment pipeline where users input minimal data (e.g., company names) and Parallel automatically researches the web to fill in the details.
 
 ![Screenshot](screenshot.png)
 


### PR DESCRIPTION
## Summary

Update README to focus on web-sourced data enrichment rather than "real-time".

## Changes

- "Build a real-time data enrichment pipeline" → "Enrich your Supabase data with live web intelligence"
- "get back enriched information automatically" → "Parallel automatically researches the web to fill in the details"

This aligns the cookbook messaging with Parallel's core value prop (web-sourced data).