### PR TITLE
Add instant deploy button for vercel

### DIFF
--- a/typescript-recipes/parallel-vercel-template/README.md
+++ b/typescript-recipes/parallel-vercel-template/README.md
@@ -2,15 +2,17 @@
 
 A Next.js template demonstrating how to integrate Parallel's web research APIs with Vercel. This template provides a complete demo application showcasing the Search, Extract, and Tasks APIs with real-time SSE streaming.
 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fparallel-web%2Fparallel-cookbook%2Ftree%2Fmain%2Ftypescript-recipes%2Fparallel-vercel-template&demo-title=Parallel%20Vercel%20Demo&demo-description=Explore%20Parallel's%20Search%2C%20Extract%2C%20and%20Tasks%20APIs%20with%20this%20interactive%20demo.&demo-url=https%3A%2F%2Fparallel-vercel-template-cookbook.vercel.app%2F&integration-ids=oac_qjiYAM8BTtX0UDS6HEPY97nU&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22parallel%22%2C%22productSlug%22%3A%22parallel%22%2C%22protocol%22%3A%22ai%22%7D%5D)
+
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Search API** | Natural language web search with mode selection (one-shot vs agentic) |
-| **Extract API** | Content extraction from URLs with objective-focused filtering |
-| **Tasks API** | Deep research tasks with real-time SSE event streaming |
+| Feature                 | Description                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| **Search API**          | Natural language web search with mode selection (one-shot vs agentic)           |
+| **Extract API**         | Content extraction from URLs with objective-focused filtering                   |
+| **Tasks API**           | Deep research tasks with real-time SSE event streaming                          |
 | **Session Persistence** | Search/Extract results persist in sessionStorage, Tasks persist in localStorage |
-| **Status Recovery** | Automatically checks and updates pending task statuses on page reload |
+| **Status Recovery**     | Automatically checks and updates pending task statuses on page reload           |
 
 ## Architecture
 
@@ -114,7 +116,7 @@ The easiest way to get an API key is through the [Parallel Vercel Integration](h
 
 ## Exploring More APIs
 
-Want to try the **Monitor** or **FindAll** APIs? 
+Want to try the **Monitor** or **FindAll** APIs?
 
 Go to your [Vercel Integration page](https://vercel.com/parallel-ai/~/integrations/parallel), select a project, and click **"Open in Parallel Web Systems"** to access the full playground.
 


### PR DESCRIPTION
Now that we have a project setup, add a instant deploy button for vercel so someone can instantly add it to their vercel project.