### PR TITLE
Vertex AI demo: support Marketplace and BYOK auth modes

### DIFF
--- a/python-recipes/vertex_ai_demo/.env.example
+++ b/python-recipes/vertex_ai_demo/.env.example
@@ -2,9 +2,6 @@
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
 
-# Parallel API Key (get from https://parallel.ai/products/search)
-PARALLEL_API_KEY=your-parallel-api-key
-
 # Optional: Path to Google Cloud credentials JSON file
 # If not set, will use Application Default Credentials (ADC)
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json

--- a/python-recipes/vertex_ai_demo/.env.example
+++ b/python-recipes/vertex_ai_demo/.env.example
@@ -2,6 +2,16 @@
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
 
+# Parallel authentication — choose ONE of the two options below.
+#
+# Option A: Google Cloud Marketplace (recommended)
+#   Subscribe at https://console.cloud.google.com/marketplace/product/parallel-web-systems-public/parallel-web-systems
+#   No API key is required; leave PARALLEL_API_KEY unset.
+#
+# Option B: Bring Your Own Key (BYOK)
+#   Get a key from https://platform.parallel.ai and set it here.
+# PARALLEL_API_KEY=your-parallel-api-key
+
 # Optional: Path to Google Cloud credentials JSON file
 # If not set, will use Application Default Credentials (ADC)
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json

--- a/python-recipes/vertex_ai_demo/README.md
+++ b/python-recipes/vertex_ai_demo/README.md
@@ -54,8 +54,13 @@ Grounding with Parallel on Vertex AI connects Gemini models to Parallel's LLM-op
 
 1. **Google Cloud Project** with billing enabled
 2. **Vertex AI API** enabled in your project
-3. **Python 3.10+** and **uv** package manager
-4. **Google Cloud authentication** configured
+3. **Parallel auth** configured via one of:
+   - **Google Cloud Marketplace** (recommended): an active [Parallel Web Search subscription](https://console.cloud.google.com/marketplace/product/parallel-web-systems-public/parallel-web-systems) on your GCP project — no API key needed, or
+   - **Bring Your Own Key (BYOK)**: a Parallel API key from [platform.parallel.ai](https://platform.parallel.ai)
+4. **Python 3.10+** and **uv** package manager
+5. **Google Cloud authentication** configured
+
+See the [Parallel + Vertex AI integration docs](https://docs.parallel.ai/integrations/google-vertex) for a comparison of the two modes.
 
 ## Quick Start
 
@@ -79,6 +84,11 @@ gcloud auth application-default login
 
 # Set your project
 export GOOGLE_CLOUD_PROJECT="your-gcp-project-id"
+
+# Optional: only if using Bring Your Own Key (BYOK) instead of a
+# Google Cloud Marketplace subscription.
+# Get a key from https://platform.parallel.ai
+# export PARALLEL_API_KEY="your-parallel-api-key"
 ```
 
 ### 3. Validate Setup
@@ -143,12 +153,14 @@ jupyter notebook tutorial.ipynb
 
 ## Usage
 
-### Basic Usage
+### Basic Usage (Google Cloud Marketplace)
+
+When your GCP project has a Parallel Web Search Marketplace subscription, no API key is needed.
 
 ```python
 from vertex_parallel import GroundedGeminiClient
 
-# Initialize the client
+# Initialize the client (Marketplace mode)
 client = GroundedGeminiClient(
     project_id="your-project-id",
 )
@@ -163,13 +175,33 @@ print(response.text)
 print(f"Sources: {[s.uri for s in response.sources]}")
 ```
 
+### Basic Usage (Bring Your Own Key)
+
+Pass `parallel_api_key` (or set `PARALLEL_API_KEY`) to authenticate with a Parallel key instead.
+
+```python
+from vertex_parallel import GroundedGeminiClient
+
+client = GroundedGeminiClient(
+    project_id="your-project-id",
+    parallel_api_key="your-parallel-api-key",
+)
+
+response = client.generate("Who won the most recent FIFA World Cup?")
+print(response.text)
+```
+
+> Note: If both a Marketplace subscription and an API key are present, the API key takes precedence.
+
 ### With Custom Configuration
 
 ```python
 from vertex_parallel import GroundedGeminiClient, GroundingConfig
 
-# Configure grounding options
+# Configure grounding options. Leave api_key unset for Marketplace mode,
+# or pass a key for BYOK.
 config = GroundingConfig(
+    # api_key="your-parallel-api-key",  # Uncomment for BYOK
     max_results=5,                    # Max search results (1-20)
     include_domains=["www.example.com"],  # Only these domains
     exclude_domains=[],         # Exclude these domains
@@ -207,10 +239,17 @@ if not status.is_valid:
 ```python
 from vertex_parallel import generate_grounded_response
 
-# One-off grounded request
+# Marketplace
 response = generate_grounded_response(
     prompt="What are the latest breakthroughs in quantum computing?",
     project_id="your-project",
+)
+
+# BYOK
+response = generate_grounded_response(
+    prompt="What are the latest breakthroughs in quantum computing?",
+    project_id="your-project",
+    parallel_api_key="your-parallel-api-key",
 )
 ```
 
@@ -221,6 +260,7 @@ response = generate_grounded_response(
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `GOOGLE_CLOUD_PROJECT` | Google Cloud project ID | Yes |
+| `PARALLEL_API_KEY` | Parallel API key. Only required for Bring Your Own Key (BYOK) mode; leave unset when using a Google Cloud Marketplace subscription | No |
 | `GOOGLE_CLOUD_LOCATION` | GCP region (default: us-central1) | No |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON | No |
 
@@ -228,6 +268,7 @@ response = generate_grounded_response(
 
 | Parameter | Description | Default | Range |
 |-----------|-------------|---------|-------|
+| `api_key` | Parallel API key for BYOK mode. Leave unset for Marketplace. | None | - |
 | `max_results` | Max search results | 10 | 1-20 |
 | `max_chars_per_result` | Max chars per result excerpt | 30,000 | 1,000-100,000 |
 | `max_chars_total` | Max total chars from all excerpts | 100,000 | 1,000-1,000,000 |
@@ -313,7 +354,7 @@ Using Grounding with Parallel incurs the following charges:
 
 ## Quota
 
-The default quota is 60 prompts per minute. To increase rate limits, contact [support@parallel.ai](mailto:support@parallel.ai) and your Google account team.
+The default quota is 200 prompts per minute. To increase rate limits, contact your Google account team (Marketplace) or [support@parallel.ai](mailto:support@parallel.ai) (BYOK) with your use case.
 
 ## Troubleshooting
 
@@ -329,8 +370,18 @@ The default quota is 60 prompts per minute. To increase rate limits, contact [su
    gcloud services enable aiplatform.googleapis.com
    ```
 
-3. **Rate Limiting**
-   - Default quota is 60 requests/minute
+3. **Marketplace subscription missing**
+   - If you're not using BYOK, make sure the GCP project you pass to
+     `GroundedGeminiClient` has an active
+     [Parallel Web Search Marketplace subscription](https://console.cloud.google.com/marketplace/product/parallel-web-systems-public/parallel-web-systems).
+   - Otherwise set `PARALLEL_API_KEY` (or pass `parallel_api_key`) to use BYOK.
+
+4. **Invalid API Key (BYOK only)**
+   - Verify your Parallel API key at [platform.parallel.ai](https://platform.parallel.ai)
+   - Ensure the key has web search permissions
+
+5. **Rate Limiting**
+   - Default quota is 200 requests/minute
    - Contact support for higher limits
 
 ### Logs and Debugging

--- a/python-recipes/vertex_ai_demo/README.md
+++ b/python-recipes/vertex_ai_demo/README.md
@@ -54,9 +54,8 @@ Grounding with Parallel on Vertex AI connects Gemini models to Parallel's LLM-op
 
 1. **Google Cloud Project** with billing enabled
 2. **Vertex AI API** enabled in your project
-3. **Parallel API Key** from [parallel.ai/products/search](https://parallel.ai/products/search)
-4. **Python 3.10+** and **uv** package manager
-5. **Google Cloud authentication** configured
+3. **Python 3.10+** and **uv** package manager
+4. **Google Cloud authentication** configured
 
 ## Quick Start
 
@@ -80,9 +79,6 @@ gcloud auth application-default login
 
 # Set your project
 export GOOGLE_CLOUD_PROJECT="your-gcp-project-id"
-
-# Set your Parallel API key
-export PARALLEL_API_KEY="your-parallel-api-key"
 ```
 
 ### 3. Validate Setup
@@ -155,7 +151,6 @@ from vertex_parallel import GroundedGeminiClient
 # Initialize the client
 client = GroundedGeminiClient(
     project_id="your-project-id",
-    parallel_api_key="your-parallel-api-key",
 )
 
 # Generate a grounded response
@@ -175,7 +170,6 @@ from vertex_parallel import GroundedGeminiClient, GroundingConfig
 
 # Configure grounding options
 config = GroundingConfig(
-    api_key="your-parallel-api-key",
     max_results=5,                    # Max search results (1-20)
     include_domains=["www.example.com"],  # Only these domains
     exclude_domains=[],         # Exclude these domains
@@ -217,7 +211,6 @@ from vertex_parallel import generate_grounded_response
 response = generate_grounded_response(
     prompt="What are the latest breakthroughs in quantum computing?",
     project_id="your-project",
-    parallel_api_key="your-key",
 )
 ```
 
@@ -228,7 +221,6 @@ response = generate_grounded_response(
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `GOOGLE_CLOUD_PROJECT` | Google Cloud project ID | Yes |
-| `PARALLEL_API_KEY` | Parallel API key | Yes |
 | `GOOGLE_CLOUD_LOCATION` | GCP region (default: us-central1) | No |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON | No |
 
@@ -236,7 +228,6 @@ response = generate_grounded_response(
 
 | Parameter | Description | Default | Range |
 |-----------|-------------|---------|-------|
-| `api_key` | Parallel API key | Required | - |
 | `max_results` | Max search results | 10 | 1-20 |
 | `max_chars_per_result` | Max chars per result excerpt | 30,000 | 1,000-100,000 |
 | `max_chars_total` | Max total chars from all excerpts | 100,000 | 1,000-1,000,000 |
@@ -338,11 +329,7 @@ The default quota is 60 prompts per minute. To increase rate limits, contact [su
    gcloud services enable aiplatform.googleapis.com
    ```
 
-3. **Invalid API Key**
-   - Verify your Parallel API key at [parallel.ai](https://parallel.ai)
-   - Ensure the key has web search permissions
-
-4. **Rate Limiting**
+3. **Rate Limiting**
    - Default quota is 60 requests/minute
    - Contact support for higher limits
 

--- a/python-recipes/vertex_ai_demo/demo.py
+++ b/python-recipes/vertex_ai_demo/demo.py
@@ -8,13 +8,11 @@ responses with and without grounding for questions about recent events.
 
 Prerequisites:
     1. Google Cloud project with Vertex AI API enabled
-    2. Parallel API key from https://parallel.ai/products/search
-    3. Google Cloud authentication (gcloud auth application-default login)
+    2. Google Cloud authentication (gcloud auth application-default login)
 
 Usage:
     # Set required environment variables
     export GOOGLE_CLOUD_PROJECT="your-gcp-project-id"
-    export PARALLEL_API_KEY="your-parallel-api-key"
 
     # Run the demo with sample questions
     python demo.py
@@ -361,7 +359,6 @@ def main() -> None:
 
             Environment Variables:
               GOOGLE_CLOUD_PROJECT    Your GCP project ID (required)
-              PARALLEL_API_KEY        Your Parallel API key (required)
               GOOGLE_CLOUD_LOCATION   GCP region (default: us-central1)
         """),
     )
@@ -431,14 +428,12 @@ def main() -> None:
 
     project_id = status.project_id
     location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
-    parallel_api_key = os.environ.get("PARALLEL_API_KEY")
 
     # Initialize client
     try:
         client = GroundedGeminiClient(
             project_id=project_id,
             location=location,
-            parallel_api_key=parallel_api_key,
         )
         print(f"\nInitialized client for project: {project_id}")
     except Exception as e:

--- a/python-recipes/vertex_ai_demo/demo.py
+++ b/python-recipes/vertex_ai_demo/demo.py
@@ -9,10 +9,15 @@ responses with and without grounding for questions about recent events.
 Prerequisites:
     1. Google Cloud project with Vertex AI API enabled
     2. Google Cloud authentication (gcloud auth application-default login)
+    3. Parallel auth via one of:
+         - Google Cloud Marketplace subscription, or
+         - PARALLEL_API_KEY env var (Bring Your Own Key)
 
 Usage:
     # Set required environment variables
     export GOOGLE_CLOUD_PROJECT="your-gcp-project-id"
+    # Optional for BYOK:
+    # export PARALLEL_API_KEY="your-parallel-api-key"
 
     # Run the demo with sample questions
     python demo.py
@@ -359,6 +364,9 @@ def main() -> None:
 
             Environment Variables:
               GOOGLE_CLOUD_PROJECT    Your GCP project ID (required)
+              PARALLEL_API_KEY        Parallel API key (optional; only for BYOK
+                                      mode — leave unset to use a Google Cloud
+                                      Marketplace subscription)
               GOOGLE_CLOUD_LOCATION   GCP region (default: us-central1)
         """),
     )
@@ -428,14 +436,19 @@ def main() -> None:
 
     project_id = status.project_id
     location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
+    parallel_api_key = os.environ.get("PARALLEL_API_KEY")
 
-    # Initialize client
+    # Initialize client. parallel_api_key is optional: when None, the client
+    # runs in Google Cloud Marketplace mode (subscription required); when
+    # set, the client authenticates BYOK with the Parallel API key.
     try:
         client = GroundedGeminiClient(
             project_id=project_id,
             location=location,
+            parallel_api_key=parallel_api_key,
         )
-        print(f"\nInitialized client for project: {project_id}")
+        mode = "BYOK" if parallel_api_key else "Google Cloud Marketplace"
+        print(f"\nInitialized client for project: {project_id} ({mode} auth)")
     except Exception as e:
         print(f"\nError initializing client: {e}")
         print("\nMake sure you have authenticated with Google Cloud:")

--- a/python-recipes/vertex_ai_demo/quickstart.py
+++ b/python-recipes/vertex_ai_demo/quickstart.py
@@ -9,6 +9,10 @@ Prerequisites:
     2. export GOOGLE_CLOUD_PROJECT="your-project-id"
        (or set in .env file)
     3. gcloud auth application-default login
+    4. Parallel auth — choose one:
+       a) Google Cloud Marketplace subscription (no env var needed), or
+       b) Bring Your Own Key: export PARALLEL_API_KEY="your-parallel-key"
+          (or set in .env file)
 """
 
 from dotenv import load_dotenv

--- a/python-recipes/vertex_ai_demo/quickstart.py
+++ b/python-recipes/vertex_ai_demo/quickstart.py
@@ -8,9 +8,7 @@ Prerequisites:
     1. pip install vertex-parallel-grounding
     2. export GOOGLE_CLOUD_PROJECT="your-project-id"
        (or set in .env file)
-    3. export PARALLEL_API_KEY="your-api-key"
-       (or set in .env file)
-    4. gcloud auth application-default login
+    3. gcloud auth application-default login
 """
 
 from dotenv import load_dotenv

--- a/python-recipes/vertex_ai_demo/src/vertex_parallel/__init__.py
+++ b/python-recipes/vertex_ai_demo/src/vertex_parallel/__init__.py
@@ -2,14 +2,28 @@
 Vertex AI + Parallel Web Search Grounding Integration.
 
 This module provides utilities for using Parallel web search as a grounding
-source for Gemini models on Vertex AI.
+source for Gemini models on Vertex AI. Two auth modes are supported:
 
-Example usage:
+* **Google Cloud Marketplace**: Subscribe to Parallel Web Search on GCP
+  Marketplace and no API key is required in requests.
+* **Bring Your Own Key (BYOK)**: Pass a Parallel API key (or set
+  ``PARALLEL_API_KEY``) to authenticate requests directly.
+
+Example (Marketplace):
     from vertex_parallel import GroundedGeminiClient
 
     client = GroundedGeminiClient(
         project_id="your-project",
         location="us-central1",
+    )
+
+Example (BYOK):
+    from vertex_parallel import GroundedGeminiClient
+
+    client = GroundedGeminiClient(
+        project_id="your-project",
+        location="us-central1",
+        parallel_api_key="your-parallel-key",
     )
 
     response = client.generate(

--- a/python-recipes/vertex_ai_demo/src/vertex_parallel/__init__.py
+++ b/python-recipes/vertex_ai_demo/src/vertex_parallel/__init__.py
@@ -10,7 +10,6 @@ Example usage:
     client = GroundedGeminiClient(
         project_id="your-project",
         location="us-central1",
-        parallel_api_key="your-parallel-key"
     )
 
     response = client.generate(

--- a/python-recipes/vertex_ai_demo/src/vertex_parallel/client.py
+++ b/python-recipes/vertex_ai_demo/src/vertex_parallel/client.py
@@ -30,7 +30,6 @@ class SetupStatus:
     Attributes:
         is_valid: Whether all checks passed.
         project_id: The GCP project ID found (or None).
-        parallel_api_key_set: Whether a Parallel API key is configured.
         gcp_auth_valid: Whether GCP authentication is working.
         errors: List of error messages for failed checks.
         warnings: List of warning messages for potential issues.
@@ -38,7 +37,6 @@ class SetupStatus:
 
     is_valid: bool
     project_id: str | None
-    parallel_api_key_set: bool
     gcp_auth_valid: bool
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
@@ -55,7 +53,6 @@ class SetupStatus:
         # Configuration
         lines.append("Configuration:")
         lines.append(f"  GCP Project: {self.project_id or 'NOT SET'}")
-        lines.append(f"  Parallel API Key: {'SET' if self.parallel_api_key_set else 'NOT SET'}")
         lines.append(f"  GCP Authentication: {'VALID' if self.gcp_auth_valid else 'INVALID'}")
 
         # Errors
@@ -78,9 +75,6 @@ class SetupStatus:
             lines.append("To fix:")
             if not self.project_id:
                 lines.append("  export GOOGLE_CLOUD_PROJECT='your-project-id'")
-            if not self.parallel_api_key_set:
-                lines.append("  export PARALLEL_API_KEY='your-api-key'")
-                lines.append("  Get your key at: https://parallel.ai/products/search")
             if not self.gcp_auth_valid:
                 lines.append("  gcloud auth application-default login")
 
@@ -89,18 +83,15 @@ class SetupStatus:
 
 def validate_setup(
     project_id: str | None = None,
-    parallel_api_key: str | None = None,
 ) -> SetupStatus:
     """Validate that all required configuration is in place.
 
     This function checks:
     1. GCP project ID is set (via argument or environment variable)
-    2. Parallel API key is set (via argument or environment variable)
-    3. GCP authentication is working (can obtain access token)
+    2. GCP authentication is working (can obtain access token)
 
     Args:
         project_id: Optional project ID to check (falls back to env var).
-        parallel_api_key: Optional API key to check (falls back to env var).
 
     Returns:
         SetupStatus with validation results.
@@ -118,12 +109,6 @@ def validate_setup(
     found_project_id = project_id or os.environ.get("GOOGLE_CLOUD_PROJECT")
     if not found_project_id:
         errors.append("GOOGLE_CLOUD_PROJECT environment variable is not set")
-
-    # Check Parallel API key
-    found_api_key = parallel_api_key or os.environ.get("PARALLEL_API_KEY")
-    parallel_api_key_set = bool(found_api_key)
-    if not parallel_api_key_set:
-        errors.append("PARALLEL_API_KEY environment variable is not set")
 
     # Check GCP authentication
     gcp_auth_valid = False
@@ -149,7 +134,6 @@ def validate_setup(
     return SetupStatus(
         is_valid=is_valid,
         project_id=found_project_id,
-        parallel_api_key_set=parallel_api_key_set,
         gcp_auth_valid=gcp_auth_valid,
         errors=errors,
         warnings=warnings,
@@ -160,7 +144,6 @@ class GroundingConfig(BaseModel):
     """Configuration for Parallel web search grounding.
 
     Attributes:
-        api_key: Parallel API key for web search.
         max_results: Maximum number of search results (1-20, default 10).
         max_chars_per_result: Max characters per result excerpt (1000-100000, default 30000).
         max_chars_total: Max total characters from all excerpts (1000-1000000, default 100000).
@@ -168,7 +151,6 @@ class GroundingConfig(BaseModel):
         exclude_domains: Optional list of domains to exclude (max 10).
     """
 
-    api_key: str
     max_results: int = 10
     max_chars_per_result: int = 30000
     max_chars_total: int = 100000
@@ -177,9 +159,7 @@ class GroundingConfig(BaseModel):
 
     def to_grounding_spec(self) -> dict[str, Any]:
         """Convert to Vertex AI grounding specification format."""
-        parallel_config: dict[str, Any] = {
-            "api_key": self.api_key,
-        }
+        parallel_config: dict[str, Any] = {}
 
         # Build customConfigs if any non-default values are set
         custom_configs: dict[str, Any] = {}
@@ -337,7 +317,6 @@ class GroundedGeminiClient:
         client = GroundedGeminiClient(
             project_id="my-project",
             location="us-central1",
-            parallel_api_key="my-parallel-key"
         )
         response = client.generate("What is the latest news about AI?")
         print(response.text)
@@ -364,7 +343,6 @@ class GroundedGeminiClient:
         self,
         project_id: str | None = None,
         location: str = "us-central1",
-        parallel_api_key: str | None = None,
         grounding_config: GroundingConfig | None = None,
     ):
         """Initialize the client.
@@ -373,8 +351,6 @@ class GroundedGeminiClient:
             project_id: Google Cloud project ID. If not provided, will attempt
                 to get from GOOGLE_CLOUD_PROJECT environment variable.
             location: Google Cloud region. Defaults to us-central1.
-            parallel_api_key: Parallel API key. If not provided, will attempt
-                to get from PARALLEL_API_KEY environment variable.
             grounding_config: Optional GroundingConfig for advanced settings.
         """
         self.project_id = project_id or os.environ.get("GOOGLE_CLOUD_PROJECT")
@@ -385,18 +361,8 @@ class GroundedGeminiClient:
 
         self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
 
-        # Get Parallel API key
-        api_key = parallel_api_key or os.environ.get("PARALLEL_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "parallel_api_key must be provided or PARALLEL_API_KEY must be set"
-            )
-
         # Set up grounding config
-        if grounding_config:
-            self.grounding_config = grounding_config
-        else:
-            self.grounding_config = GroundingConfig(api_key=api_key)
+        self.grounding_config = grounding_config or GroundingConfig()
 
         # Initialize credentials
         self._credentials, _ = google.auth.default()
@@ -562,7 +528,6 @@ def generate_grounded_response(
     prompt: str,
     project_id: str | None = None,
     location: str = "us-central1",
-    parallel_api_key: str | None = None,
     model_id: str = "gemini-2.5-flash",
     **kwargs: Any,
 ) -> GroundedResponse:
@@ -572,7 +537,6 @@ def generate_grounded_response(
         prompt: The user prompt/question.
         project_id: Google Cloud project ID.
         location: Google Cloud region.
-        parallel_api_key: Parallel API key.
         model_id: The Gemini model to use.
         **kwargs: Additional arguments passed to generate().
 
@@ -583,13 +547,11 @@ def generate_grounded_response(
         response = generate_grounded_response(
             "What are the latest breakthroughs in quantum computing?",
             project_id="my-project",
-            parallel_api_key="my-key",
         )
         print(response.text)
     """
     client = GroundedGeminiClient(
         project_id=project_id,
         location=location,
-        parallel_api_key=parallel_api_key,
     )
     return client.generate(prompt, model_id=model_id, **kwargs)

--- a/python-recipes/vertex_ai_demo/src/vertex_parallel/client.py
+++ b/python-recipes/vertex_ai_demo/src/vertex_parallel/client.py
@@ -31,6 +31,8 @@ class SetupStatus:
         is_valid: Whether all checks passed.
         project_id: The GCP project ID found (or None).
         gcp_auth_valid: Whether GCP authentication is working.
+        auth_mode: Which Parallel auth mode is configured:
+            "byok" if a Parallel API key is set, otherwise "marketplace".
         errors: List of error messages for failed checks.
         warnings: List of warning messages for potential issues.
     """
@@ -38,6 +40,7 @@ class SetupStatus:
     is_valid: bool
     project_id: str | None
     gcp_auth_valid: bool
+    auth_mode: str
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
@@ -54,6 +57,13 @@ class SetupStatus:
         lines.append("Configuration:")
         lines.append(f"  GCP Project: {self.project_id or 'NOT SET'}")
         lines.append(f"  GCP Authentication: {'VALID' if self.gcp_auth_valid else 'INVALID'}")
+        if self.auth_mode == "byok":
+            lines.append("  Parallel Auth: BYOK (PARALLEL_API_KEY is set)")
+        else:
+            lines.append(
+                "  Parallel Auth: Google Cloud Marketplace "
+                "(no PARALLEL_API_KEY; requires an active subscription)"
+            )
 
         # Errors
         if self.errors:
@@ -83,15 +93,29 @@ class SetupStatus:
 
 def validate_setup(
     project_id: str | None = None,
+    parallel_api_key: str | None = None,
 ) -> SetupStatus:
     """Validate that all required configuration is in place.
 
+    Two Parallel auth modes are supported:
+
+    * **Google Cloud Marketplace**: No API key required. Subscribe to Parallel
+      Web Search on Google Cloud Marketplace and use the same GCP project for
+      Vertex AI requests.
+    * **Bring Your Own Key (BYOK)**: Set ``PARALLEL_API_KEY`` (or pass
+      ``parallel_api_key``) to authenticate requests with a key from
+      https://platform.parallel.ai.
+
     This function checks:
-    1. GCP project ID is set (via argument or environment variable)
-    2. GCP authentication is working (can obtain access token)
+    1. GCP project ID is set (via argument or environment variable).
+    2. GCP authentication is working (can obtain access token).
+    3. Detects whether ``PARALLEL_API_KEY`` is set to report the auth mode.
 
     Args:
         project_id: Optional project ID to check (falls back to env var).
+        parallel_api_key: Optional Parallel API key to check (falls back to
+            ``PARALLEL_API_KEY`` env var). If neither is set, Marketplace
+            mode is assumed.
 
     Returns:
         SetupStatus with validation results.
@@ -109,6 +133,12 @@ def validate_setup(
     found_project_id = project_id or os.environ.get("GOOGLE_CLOUD_PROJECT")
     if not found_project_id:
         errors.append("GOOGLE_CLOUD_PROJECT environment variable is not set")
+
+    # Determine Parallel auth mode. Presence of a key => BYOK; otherwise
+    # assume Marketplace (requires an active subscription, which we can't
+    # verify from the client).
+    found_api_key = parallel_api_key or os.environ.get("PARALLEL_API_KEY")
+    auth_mode = "byok" if found_api_key else "marketplace"
 
     # Check GCP authentication
     gcp_auth_valid = False
@@ -129,12 +159,21 @@ def validate_setup(
     if found_project_id and not found_project_id.replace("-", "").replace("_", "").isalnum():
         warnings.append(f"Project ID '{found_project_id}' may be invalid")
 
+    if auth_mode == "marketplace":
+        warnings.append(
+            "No PARALLEL_API_KEY detected; assuming Google Cloud Marketplace "
+            "subscription. Subscribe at "
+            "https://console.cloud.google.com/marketplace/product/parallel-web-systems-public/parallel-web-systems "
+            "or set PARALLEL_API_KEY to use BYOK."
+        )
+
     is_valid = len(errors) == 0
 
     return SetupStatus(
         is_valid=is_valid,
         project_id=found_project_id,
         gcp_auth_valid=gcp_auth_valid,
+        auth_mode=auth_mode,
         errors=errors,
         warnings=warnings,
     )
@@ -143,7 +182,18 @@ def validate_setup(
 class GroundingConfig(BaseModel):
     """Configuration for Parallel web search grounding.
 
+    Supports both Parallel auth modes on Vertex AI:
+
+    * **Google Cloud Marketplace**: Leave ``api_key`` unset. Authentication
+      is handled by your GCP project's Marketplace subscription.
+    * **Bring Your Own Key (BYOK)**: Set ``api_key`` to a Parallel API key
+      from https://platform.parallel.ai. The key is included in each
+      grounded request.
+
     Attributes:
+        api_key: Optional Parallel API key. When set, requests are
+            authenticated in BYOK mode. When ``None``, Marketplace mode is
+            used and no ``api_key`` field is sent.
         max_results: Maximum number of search results (1-20, default 10).
         max_chars_per_result: Max characters per result excerpt (1000-100000, default 30000).
         max_chars_total: Max total characters from all excerpts (1000-1000000, default 100000).
@@ -151,6 +201,7 @@ class GroundingConfig(BaseModel):
         exclude_domains: Optional list of domains to exclude (max 10).
     """
 
+    api_key: str | None = None
     max_results: int = 10
     max_chars_per_result: int = 30000
     max_chars_total: int = 100000
@@ -158,8 +209,17 @@ class GroundingConfig(BaseModel):
     exclude_domains: list[str] | None = None
 
     def to_grounding_spec(self) -> dict[str, Any]:
-        """Convert to Vertex AI grounding specification format."""
+        """Convert to Vertex AI grounding specification format.
+
+        If ``api_key`` is set, it is included in the ``parallelAiSearch``
+        object (BYOK mode). Otherwise the key is omitted and authentication
+        falls back to the Google Cloud Marketplace subscription.
+        """
         parallel_config: dict[str, Any] = {}
+
+        # BYOK: include api_key only when explicitly provided.
+        if self.api_key:
+            parallel_config["api_key"] = self.api_key
 
         # Build customConfigs if any non-default values are set
         custom_configs: dict[str, Any] = {}
@@ -311,13 +371,28 @@ class GroundedGeminiClient:
     """Client for making grounded requests to Gemini via Vertex AI.
 
     This client uses the Vertex AI REST API to make requests to Gemini models
-    with Parallel web search grounding enabled.
+    with Parallel web search grounding enabled. It supports both Parallel
+    auth modes:
 
-    Example:
+    * **Google Cloud Marketplace** (default when no key is provided): the
+      GCP project's Marketplace subscription authenticates the request.
+    * **Bring Your Own Key (BYOK)**: pass ``parallel_api_key`` or set the
+      ``PARALLEL_API_KEY`` environment variable, and the key is included
+      in each request.
+
+    Example (Marketplace):
         client = GroundedGeminiClient(
             project_id="my-project",
             location="us-central1",
         )
+
+    Example (BYOK):
+        client = GroundedGeminiClient(
+            project_id="my-project",
+            location="us-central1",
+            parallel_api_key="your-parallel-key",
+        )
+
         response = client.generate("What is the latest news about AI?")
         print(response.text)
         for source in response.sources:
@@ -343,6 +418,7 @@ class GroundedGeminiClient:
         self,
         project_id: str | None = None,
         location: str = "us-central1",
+        parallel_api_key: str | None = None,
         grounding_config: GroundingConfig | None = None,
     ):
         """Initialize the client.
@@ -351,7 +427,13 @@ class GroundedGeminiClient:
             project_id: Google Cloud project ID. If not provided, will attempt
                 to get from GOOGLE_CLOUD_PROJECT environment variable.
             location: Google Cloud region. Defaults to us-central1.
+            parallel_api_key: Optional Parallel API key for Bring Your Own
+                Key (BYOK) mode. If not provided, falls back to the
+                ``PARALLEL_API_KEY`` environment variable. If neither is set,
+                the client runs in Google Cloud Marketplace mode and no key
+                is sent in requests.
             grounding_config: Optional GroundingConfig for advanced settings.
+                If it already has ``api_key`` set, that takes precedence.
         """
         self.project_id = project_id or os.environ.get("GOOGLE_CLOUD_PROJECT")
         if not self.project_id:
@@ -361,8 +443,20 @@ class GroundedGeminiClient:
 
         self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
 
-        # Set up grounding config
-        self.grounding_config = grounding_config or GroundingConfig()
+        # Resolve Parallel API key (BYOK). May be None => Marketplace mode.
+        resolved_api_key = parallel_api_key or os.environ.get("PARALLEL_API_KEY")
+
+        # Set up grounding config. If the caller passed a config without an
+        # api_key, inject the resolved key so BYOK works without the caller
+        # having to set it in two places.
+        if grounding_config is None:
+            self.grounding_config = GroundingConfig(api_key=resolved_api_key)
+        else:
+            self.grounding_config = grounding_config
+            if self.grounding_config.api_key is None and resolved_api_key:
+                self.grounding_config = self.grounding_config.model_copy(
+                    update={"api_key": resolved_api_key}
+                )
 
         # Initialize credentials
         self._credentials, _ = google.auth.default()
@@ -528,6 +622,7 @@ def generate_grounded_response(
     prompt: str,
     project_id: str | None = None,
     location: str = "us-central1",
+    parallel_api_key: str | None = None,
     model_id: str = "gemini-2.5-flash",
     **kwargs: Any,
 ) -> GroundedResponse:
@@ -537,21 +632,32 @@ def generate_grounded_response(
         prompt: The user prompt/question.
         project_id: Google Cloud project ID.
         location: Google Cloud region.
+        parallel_api_key: Optional Parallel API key (BYOK). If omitted and
+            ``PARALLEL_API_KEY`` is not set, requests use the Google Cloud
+            Marketplace subscription.
         model_id: The Gemini model to use.
         **kwargs: Additional arguments passed to generate().
 
     Returns:
         A GroundedResponse containing the text and sources.
 
-    Example:
+    Example (Marketplace):
         response = generate_grounded_response(
             "What are the latest breakthroughs in quantum computing?",
             project_id="my-project",
+        )
+
+    Example (BYOK):
+        response = generate_grounded_response(
+            "What are the latest breakthroughs in quantum computing?",
+            project_id="my-project",
+            parallel_api_key="your-parallel-key",
         )
         print(response.text)
     """
     client = GroundedGeminiClient(
         project_id=project_id,
         location=location,
+        parallel_api_key=parallel_api_key,
     )
     return client.generate(prompt, model_id=model_id, **kwargs)

--- a/python-recipes/vertex_ai_demo/tests/conftest.py
+++ b/python-recipes/vertex_ai_demo/tests/conftest.py
@@ -86,7 +86,6 @@ def env_vars():
     """Set up environment variables for testing."""
     original_env = os.environ.copy()
     os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
-    os.environ["PARALLEL_API_KEY"] = "test-api-key"
     os.environ["GOOGLE_CLOUD_LOCATION"] = "us-central1"
     yield
     os.environ.clear()

--- a/python-recipes/vertex_ai_demo/tests/test_client.py
+++ b/python-recipes/vertex_ai_demo/tests/test_client.py
@@ -15,6 +15,7 @@ class TestGroundingConfig:
     def test_default_config(self):
         """Test default configuration values."""
         config = GroundingConfig()
+        assert config.api_key is None
         assert config.max_results == 10
         assert config.max_chars_per_result == 30000
         assert config.max_chars_total == 100000
@@ -24,30 +25,42 @@ class TestGroundingConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = GroundingConfig(
+            api_key="test-key",
             max_results=5,
             max_chars_per_result=10000,
             max_chars_total=50000,
             include_domains=["example.com"],
             exclude_domains=["blocked.com"],
         )
+        assert config.api_key == "test-key"
         assert config.max_results == 5
         assert config.max_chars_per_result == 10000
         assert config.max_chars_total == 50000
         assert config.include_domains == ["example.com"]
         assert config.exclude_domains == ["blocked.com"]
 
-    def test_to_grounding_spec_minimal(self):
-        """Test conversion to grounding spec with minimal config."""
+    def test_to_grounding_spec_marketplace(self):
+        """Marketplace mode: no api_key is emitted in the spec."""
         config = GroundingConfig()
         spec = config.to_grounding_spec()
 
         assert "parallelAiSearch" in spec
+        assert "api_key" not in spec["parallelAiSearch"]
         # Default values should not be included in customConfigs
+        assert "customConfigs" not in spec["parallelAiSearch"]
+
+    def test_to_grounding_spec_byok(self):
+        """BYOK mode: api_key is emitted in the spec."""
+        config = GroundingConfig(api_key="test-key")
+        spec = config.to_grounding_spec()
+
+        assert spec["parallelAiSearch"]["api_key"] == "test-key"
         assert "customConfigs" not in spec["parallelAiSearch"]
 
     def test_to_grounding_spec_full(self):
         """Test conversion to grounding spec with all options."""
         config = GroundingConfig(
+            api_key="test-key",
             max_results=5,
             max_chars_per_result=10000,
             max_chars_total=50000,
@@ -57,6 +70,7 @@ class TestGroundingConfig:
         spec = config.to_grounding_spec()
 
         parallel_config = spec["parallelAiSearch"]
+        assert parallel_config["api_key"] == "test-key"
         assert "customConfigs" in parallel_config
         custom = parallel_config["customConfigs"]
         assert custom["max_results"] == 5
@@ -111,8 +125,9 @@ class TestGroundedResponse:
 class TestGroundedGeminiClient:
     """Tests for GroundedGeminiClient."""
 
-    def test_init_with_params(self, mock_auth):
-        """Test client initialization with explicit parameters."""
+    def test_init_with_params(self, mock_auth, monkeypatch):
+        """Marketplace mode: no API key is configured."""
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
         client = GroundedGeminiClient(
             project_id="test-project",
             location="us-central1",
@@ -120,15 +135,36 @@ class TestGroundedGeminiClient:
 
         assert client.project_id == "test-project"
         assert client.location == "us-central1"
+        assert client.grounding_config.api_key is None
 
-    def test_init_with_env_vars(self, mock_auth, env_vars):
+    def test_init_byok_with_param(self, mock_auth, monkeypatch):
+        """BYOK mode: parallel_api_key is accepted and plumbed through."""
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        client = GroundedGeminiClient(
+            project_id="test-project",
+            parallel_api_key="my-byok-key",
+        )
+
+        assert client.grounding_config.api_key == "my-byok-key"
+
+    def test_init_byok_from_env(self, mock_auth, monkeypatch):
+        """BYOK mode: PARALLEL_API_KEY env var is picked up automatically."""
+        monkeypatch.setenv("PARALLEL_API_KEY", "env-byok-key")
+        client = GroundedGeminiClient(project_id="test-project")
+
+        assert client.grounding_config.api_key == "env-byok-key"
+
+    def test_init_with_env_vars(self, mock_auth, env_vars, monkeypatch):
         """Test client initialization from environment variables."""
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
         client = GroundedGeminiClient()
 
         assert client.project_id == "test-project"
+        assert client.grounding_config.api_key is None
 
-    def test_init_missing_project(self, mock_auth):
+    def test_init_missing_project(self, mock_auth, monkeypatch):
         """Test that missing project ID raises error."""
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
         with pytest.raises(ValueError, match="project_id must be provided"):
             GroundedGeminiClient()
 
@@ -144,8 +180,9 @@ class TestGroundedGeminiClient:
         assert url == expected
 
     @patch("requests.post")
-    def test_generate(self, mock_post, mock_auth, sample_api_response):
-        """Test the generate method."""
+    def test_generate(self, mock_post, mock_auth, sample_api_response, monkeypatch):
+        """Test the generate method in Marketplace mode (no api_key sent)."""
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
         mock_response = MagicMock()
         mock_response.json.return_value = sample_api_response
         mock_response.raise_for_status = MagicMock()
@@ -166,7 +203,31 @@ class TestGroundedGeminiClient:
         request_body = call_args.kwargs["json"]
         assert "contents" in request_body
         assert "tools" in request_body
-        assert "parallelAiSearch" in request_body["tools"][0]
+        parallel_tool = request_body["tools"][0]["parallelAiSearch"]
+        # Marketplace: api_key must NOT be present in the request body
+        assert "api_key" not in parallel_tool
+
+    @patch("requests.post")
+    def test_generate_byok_sends_api_key(
+        self, mock_post, mock_auth, sample_api_response, monkeypatch
+    ):
+        """BYOK mode: api_key is included in the request body."""
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_api_response
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = GroundedGeminiClient(
+            project_id="test-project",
+            parallel_api_key="my-byok-key",
+        )
+
+        client.generate("What is the CEO of Example Corp?")
+
+        request_body = mock_post.call_args.kwargs["json"]
+        parallel_tool = request_body["tools"][0]["parallelAiSearch"]
+        assert parallel_tool["api_key"] == "my-byok-key"
 
     @patch("requests.post")
     def test_generate_with_options(self, mock_post, mock_auth, sample_api_response):

--- a/python-recipes/vertex_ai_demo/tests/test_client.py
+++ b/python-recipes/vertex_ai_demo/tests/test_client.py
@@ -14,8 +14,7 @@ class TestGroundingConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = GroundingConfig(api_key="test-key")
-        assert config.api_key == "test-key"
+        config = GroundingConfig()
         assert config.max_results == 10
         assert config.max_chars_per_result == 30000
         assert config.max_chars_total == 100000
@@ -25,7 +24,6 @@ class TestGroundingConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = GroundingConfig(
-            api_key="test-key",
             max_results=5,
             max_chars_per_result=10000,
             max_chars_total=50000,
@@ -40,18 +38,16 @@ class TestGroundingConfig:
 
     def test_to_grounding_spec_minimal(self):
         """Test conversion to grounding spec with minimal config."""
-        config = GroundingConfig(api_key="test-key")
+        config = GroundingConfig()
         spec = config.to_grounding_spec()
 
         assert "parallelAiSearch" in spec
-        assert spec["parallelAiSearch"]["api_key"] == "test-key"
         # Default values should not be included in customConfigs
         assert "customConfigs" not in spec["parallelAiSearch"]
 
     def test_to_grounding_spec_full(self):
         """Test conversion to grounding spec with all options."""
         config = GroundingConfig(
-            api_key="test-key",
             max_results=5,
             max_chars_per_result=10000,
             max_chars_total=50000,
@@ -61,7 +57,6 @@ class TestGroundingConfig:
         spec = config.to_grounding_spec()
 
         parallel_config = spec["parallelAiSearch"]
-        assert parallel_config["api_key"] == "test-key"
         assert "customConfigs" in parallel_config
         custom = parallel_config["customConfigs"]
         assert custom["max_results"] == 5
@@ -121,38 +116,27 @@ class TestGroundedGeminiClient:
         client = GroundedGeminiClient(
             project_id="test-project",
             location="us-central1",
-            parallel_api_key="test-key",
         )
 
         assert client.project_id == "test-project"
         assert client.location == "us-central1"
-        assert client.grounding_config.api_key == "test-key"
 
     def test_init_with_env_vars(self, mock_auth, env_vars):
         """Test client initialization from environment variables."""
         client = GroundedGeminiClient()
 
         assert client.project_id == "test-project"
-        assert client.grounding_config.api_key == "test-api-key"
 
     def test_init_missing_project(self, mock_auth):
         """Test that missing project ID raises error."""
         with pytest.raises(ValueError, match="project_id must be provided"):
-            GroundedGeminiClient(parallel_api_key="test-key")
-
-    def test_init_missing_api_key(self, mock_auth, monkeypatch):
-        """Test that missing API key raises error."""
-        # Clear the environment variable if set
-        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="parallel_api_key must be provided"):
-            GroundedGeminiClient(project_id="test-project")
+            GroundedGeminiClient()
 
     def test_get_endpoint_url(self, mock_auth):
         """Test endpoint URL generation."""
         client = GroundedGeminiClient(
             project_id="my-project",
             location="us-central1",
-            parallel_api_key="test-key",
         )
 
         url = client._get_endpoint_url("gemini-2.0-flash")
@@ -169,7 +153,6 @@ class TestGroundedGeminiClient:
 
         client = GroundedGeminiClient(
             project_id="test-project",
-            parallel_api_key="test-key",
         )
 
         response = client.generate("What is the CEO of Example Corp?")
@@ -195,7 +178,6 @@ class TestGroundedGeminiClient:
 
         client = GroundedGeminiClient(
             project_id="test-project",
-            parallel_api_key="test-key",
         )
 
         _response = client.generate(
@@ -224,7 +206,6 @@ class TestGroundedGeminiClient:
 
         client = GroundedGeminiClient(
             project_id="test-project",
-            parallel_api_key="test-key",
         )
 
         _response = client.generate_with_context(

--- a/python-recipes/vertex_ai_demo/tutorial.ipynb
+++ b/python-recipes/vertex_ai_demo/tutorial.ipynb
@@ -17,8 +17,7 @@
     "## Prerequisites\n",
     "\n",
     "1. A Google Cloud project with Vertex AI API enabled\n",
-    "2. A Parallel API key from https://parallel.ai/products/search\n",
-    "3. Google Cloud authentication configured (`gcloud auth application-default login`)"
+    "2. Google Cloud authentication configured (`gcloud auth application-default login`)"
    ]
   },
   {
@@ -32,9 +31,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project: matt-h-gcp-test\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "\n",
@@ -50,12 +57,10 @@
     "\n",
     "# Configuration - set these or use environment variables\n",
     "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\")\n",
-    "PARALLEL_API_KEY = os.environ.get(\"PARALLEL_API_KEY\")\n",
     "LOCATION = \"us-central1\"\n",
     "\n",
     "# Validate setup\n",
     "assert PROJECT_ID, \"Set GOOGLE_CLOUD_PROJECT environment variable\"\n",
-    "assert PARALLEL_API_KEY, \"Set PARALLEL_API_KEY environment variable\"\n",
     "print(f\"Project: {PROJECT_ID}\")"
    ]
   },
@@ -70,11 +75,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def build_grounding_config(api_key: str, max_results: int = 10) -> dict:\n",
+    "def build_grounding_config(max_results: int = 10) -> dict:\n",
     "    \"\"\"\n",
     "    Build the grounding configuration for Parallel web search.\n",
     "    \n",
@@ -83,7 +88,6 @@
     "    \"\"\"\n",
     "    return {\n",
     "        \"parallelAiSearch\": {\n",
-    "            \"api_key\": api_key,\n",
     "            # Optional: customize search behavior\n",
     "            # \"customConfigs\": {\n",
     "            #     \"max_results\": 5,\n",
@@ -95,7 +99,7 @@
     "        }\n",
     "    }\n",
     "\n",
-    "grounding_config = build_grounding_config(PARALLEL_API_KEY)"
+    "grounding_config = build_grounding_config()"
    ]
   },
   {
@@ -109,9 +113,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Functions defined\n"
+     ]
+    }
+   ],
    "source": [
     "def get_access_token():\n",
     "    \"\"\"Get a Google Cloud access token for API authentication.\"\"\"\n",
@@ -144,7 +156,7 @@
     "            }\n",
     "        ],\n",
     "        # This is the key part - adding the grounding tool\n",
-    "        \"tools\": [build_grounding_config(PARALLEL_API_KEY)],\n",
+    "        \"tools\": [build_grounding_config()],\n",
     "        \"generationConfig\": {\n",
     "            \"temperature\": 0.2\n",
     "        }\n",
@@ -212,15 +224,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Ask a question about recent events\n",
-    "question = \"What was the final score of the most recent Los Angeles Lakers game?\"\n",
-    "raw_response = generate_with_grounding(question)\n",
-    "\n",
-    "# Let's look at the raw response structure\n",
-    "print(\"Response keys:\", raw_response.keys())\n",
-    "print(\"\\nCandidate keys:\", raw_response[\"candidates\"][0].keys())"
-   ]
+   "source": "# Ask a question about recent events\nquestion = \"What was the final score of the most recent Los Angeles Lakers game?\"\n\ntry:\n    raw_response = generate_with_grounding(question)\n    # Let's look at the raw response structure\n    print(\"Response keys:\", raw_response.keys())\n    print(\"\\nCandidate keys:\", raw_response[\"candidates\"][0].keys())\nexcept requests.HTTPError as e:\n    print(f\"Status: {e.response.status_code}\")\n    print(f\"Response body: {e.response.text[:2000]}\")"
   },
   {
    "cell_type": "markdown",
@@ -233,9 +237,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'raw_response' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 52\u001b[39m\n\u001b[32m     44\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m {\n\u001b[32m     45\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mtext\u001b[39m\u001b[33m\"\u001b[39m: text,\n\u001b[32m     46\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33msources\u001b[39m\u001b[33m\"\u001b[39m: sources,\n\u001b[32m     47\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mqueries\u001b[39m\u001b[33m\"\u001b[39m: queries\n\u001b[32m     48\u001b[39m     }\n\u001b[32m     51\u001b[39m \u001b[38;5;66;03m# Parse our response\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m52\u001b[39m result = parse_grounded_response(\u001b[43mraw_response\u001b[49m)\n\u001b[32m     54\u001b[39m \u001b[38;5;66;03m# Display nicely\u001b[39;00m\n\u001b[32m     55\u001b[39m sources_md = \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m.join([\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m- [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00ms[\u001b[33m'\u001b[39m\u001b[33mtitle\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m](\u001b[39m\u001b[38;5;132;01m{\u001b[39;00ms[\u001b[33m'\u001b[39m\u001b[33muri\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m)\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m result[\u001b[33m\"\u001b[39m\u001b[33msources\u001b[39m\u001b[33m\"\u001b[39m][:\u001b[32m5\u001b[39m]])\n",
+      "\u001b[31mNameError\u001b[39m: name 'raw_response' is not defined"
+     ]
+    }
+   ],
    "source": [
     "def parse_grounded_response(response: dict) -> dict:\n",
     "    \"\"\"\n",
@@ -368,7 +384,7 @@
     "\n",
     "You've learned:\n",
     "\n",
-    "1. **Grounding config** - Add `tools: [{\"parallelAiSearch\": {\"api_key\": \"...\"}}]` to your request\n",
+    "1. **Grounding config** - Add `tools: [{\"parallelAiSearch\": {}}]` to your request\n",
     "2. **Making calls** - Use the standard Vertex AI REST API with the grounding tool\n",
     "3. **Parsing responses** - Extract text from `candidates[0].content.parts[0].text` and sources from `groundingMetadata.groundingChunks`\n",
     "4. **Customization** - Use `customConfigs` to filter domains and limit results\n",

--- a/python-recipes/vertex_ai_demo/tutorial.ipynb
+++ b/python-recipes/vertex_ai_demo/tutorial.ipynb
@@ -3,22 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Vertex AI + Parallel Web Search Grounding Tutorial\n",
-    "\n",
-    "This notebook teaches you how to ground Gemini responses with real-time web data using Parallel's web search API.\n",
-    "\n",
-    "**What you'll learn:**\n",
-    "1. How the Parallel grounding integration works\n",
-    "2. How to make grounded API calls to Vertex AI\n",
-    "3. How to parse sources and citations from responses\n",
-    "4. How to compare grounded vs. ungrounded responses\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "1. A Google Cloud project with Vertex AI API enabled\n",
-    "2. Google Cloud authentication configured (`gcloud auth application-default login`)"
-   ]
+   "source": "# Vertex AI + Parallel Web Search Grounding Tutorial\n\nThis notebook teaches you how to ground Gemini responses with real-time web data using Parallel's web search API.\n\n**What you'll learn:**\n1. How the Parallel grounding integration works\n2. How to make grounded API calls to Vertex AI\n3. How to parse sources and citations from responses\n4. How to compare grounded vs. ungrounded responses\n\n## Prerequisites\n\n1. A Google Cloud project with Vertex AI API enabled\n2. Google Cloud authentication configured (`gcloud auth application-default login`)\n3. Parallel auth via **one** of:\n    - **Google Cloud Marketplace** \u2014 an active [Parallel Web Search subscription](https://console.cloud.google.com/marketplace/product/parallel-web-systems-public/parallel-web-systems) on your GCP project. No API key needed.\n    - **Bring Your Own Key (BYOK)** \u2014 set `PARALLEL_API_KEY` with a key from [platform.parallel.ai](https://platform.parallel.ai).\n\nSee the [integration docs](https://docs.parallel.ai/integrations/google-vertex) for a comparison of the two modes."
   },
   {
    "cell_type": "markdown",
@@ -31,76 +16,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Project: matt-h-gcp-test\n"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "\n",
-    "import google.auth\n",
-    "import google.auth.transport.requests\n",
-    "import requests\n",
-    "\n",
-    "# Load from .env file if available\n",
-    "from dotenv import load_dotenv\n",
-    "from IPython.display import Markdown, display\n",
-    "\n",
-    "load_dotenv()\n",
-    "\n",
-    "# Configuration - set these or use environment variables\n",
-    "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\")\n",
-    "LOCATION = \"us-central1\"\n",
-    "\n",
-    "# Validate setup\n",
-    "assert PROJECT_ID, \"Set GOOGLE_CLOUD_PROJECT environment variable\"\n",
-    "print(f\"Project: {PROJECT_ID}\")"
-   ]
+   "outputs": [],
+   "source": "import os\n\nimport google.auth\nimport google.auth.transport.requests\nimport requests\n\n# Load from .env file if available\nfrom dotenv import load_dotenv\nfrom IPython.display import Markdown, display\n\nload_dotenv()\n\n# Configuration - set these or use environment variables\nPROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\")\nLOCATION = \"us-central1\"\n\n# Parallel API key is OPTIONAL:\n#   - If set: Bring Your Own Key (BYOK) mode \u2014 included in each request.\n#   - If unset: Google Cloud Marketplace mode \u2014 auth via your GCP\n#     project's Marketplace subscription.\nPARALLEL_API_KEY = os.environ.get(\"PARALLEL_API_KEY\")\n\n# Validate setup\nassert PROJECT_ID, \"Set GOOGLE_CLOUD_PROJECT environment variable\"\nprint(f\"Project: {PROJECT_ID}\")\nprint(f\"Parallel auth: {'BYOK' if PARALLEL_API_KEY else 'Google Cloud Marketplace'}\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Step 2: Understanding the Grounding Config\n",
-    "\n",
-    "To enable Parallel web search grounding, we add a `tools` parameter to our API request. Here's the structure:"
-   ]
+   "source": "## Step 2: Understanding the Grounding Config\n\nTo enable Parallel web search grounding, we add a `tools` parameter to our API request.\n\n- **Marketplace**: send `{\"parallelAiSearch\": {}}` \u2014 no key needed.\n- **BYOK**: send `{\"parallelAiSearch\": {\"api_key\": \"...\"}}`.\n\nThe helper below handles both cases."
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def build_grounding_config(max_results: int = 10) -> dict:\n",
-    "    \"\"\"\n",
-    "    Build the grounding configuration for Parallel web search.\n",
-    "    \n",
-    "    This config tells Vertex AI to use Parallel's web search API\n",
-    "    to ground the model's responses with real-time web data.\n",
-    "    \"\"\"\n",
-    "    return {\n",
-    "        \"parallelAiSearch\": {\n",
-    "            # Optional: customize search behavior\n",
-    "            # \"customConfigs\": {\n",
-    "            #     \"max_results\": 5,\n",
-    "            #     \"source_policy\": {\n",
-    "            #         \"include_domains\": [\"www.example.com\"],\n",
-    "            #         \"exclude_domains\": []\n",
-    "            #     }\n",
-    "            # }\n",
-    "        }\n",
-    "    }\n",
-    "\n",
-    "grounding_config = build_grounding_config()"
-   ]
+   "source": "def build_grounding_config(api_key: str | None = None, max_results: int = 10) -> dict:\n    \"\"\"\n    Build the grounding configuration for Parallel web search.\n\n    This config tells Vertex AI to use Parallel's web search API\n    to ground the model's responses with real-time web data.\n\n    Args:\n        api_key: Parallel API key for BYOK mode. When None, the call\n            relies on a Google Cloud Marketplace subscription and no\n            key is included in the request body.\n        max_results: (unused in this minimal config; see the commented\n            customConfigs block below for how to wire it up).\n    \"\"\"\n    parallel_config: dict = {}\n\n    # BYOK: include api_key only when one is provided.\n    if api_key:\n        parallel_config[\"api_key\"] = api_key\n\n    # Optional: customize search behavior\n    # parallel_config[\"customConfigs\"] = {\n    #     \"max_results\": 5,\n    #     \"source_policy\": {\n    #         \"include_domains\": [\"www.example.com\"],\n    #         \"exclude_domains\": []\n    #     }\n    # }\n\n    return {\"parallelAiSearch\": parallel_config}\n\n\ngrounding_config = build_grounding_config(PARALLEL_API_KEY)"
   },
   {
    "cell_type": "markdown",
@@ -113,102 +44,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Functions defined\n"
-     ]
-    }
-   ],
-   "source": [
-    "def get_access_token():\n",
-    "    \"\"\"Get a Google Cloud access token for API authentication.\"\"\"\n",
-    "    credentials, _ = google.auth.default()\n",
-    "    auth_req = google.auth.transport.requests.Request()\n",
-    "    credentials.refresh(auth_req)\n",
-    "    return credentials.token\n",
-    "\n",
-    "\n",
-    "def generate_with_grounding(prompt: str, model_id: str = \"gemini-2.5-flash\") -> dict:\n",
-    "    \"\"\"\n",
-    "    Call Vertex AI Gemini with Parallel web search grounding.\n",
-    "    \n",
-    "    Args:\n",
-    "        prompt: The question to ask\n",
-    "        model_id: Which Gemini model to use\n",
-    "        \n",
-    "    Returns:\n",
-    "        The raw API response as a dictionary\n",
-    "    \"\"\"\n",
-    "    # Build the API endpoint URL\n",
-    "    url = f\"https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{model_id}:generateContent\"\n",
-    "    \n",
-    "    # Build the request body\n",
-    "    request_body = {\n",
-    "        \"contents\": [\n",
-    "            {\n",
-    "                \"role\": \"user\",\n",
-    "                \"parts\": [{\"text\": prompt}]\n",
-    "            }\n",
-    "        ],\n",
-    "        # This is the key part - adding the grounding tool\n",
-    "        \"tools\": [build_grounding_config()],\n",
-    "        \"generationConfig\": {\n",
-    "            \"temperature\": 0.2\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    # Make the API call\n",
-    "    response = requests.post(\n",
-    "        url,\n",
-    "        headers={\n",
-    "            \"Authorization\": f\"Bearer {get_access_token()}\",\n",
-    "            \"Content-Type\": \"application/json\",\n",
-    "        },\n",
-    "        json=request_body,\n",
-    "        timeout=120,\n",
-    "    )\n",
-    "    response.raise_for_status()\n",
-    "    return response.json()\n",
-    "\n",
-    "\n",
-    "def generate_without_grounding(prompt: str, model_id: str = \"gemini-2.5-flash\") -> dict:\n",
-    "    \"\"\"\n",
-    "    Call Vertex AI Gemini WITHOUT grounding (for comparison).\n",
-    "    \"\"\"\n",
-    "    url = f\"https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{model_id}:generateContent\"\n",
-    "    \n",
-    "    request_body = {\n",
-    "        \"contents\": [\n",
-    "            {\n",
-    "                \"role\": \"user\",\n",
-    "                \"parts\": [{\"text\": prompt}]\n",
-    "            }\n",
-    "        ],\n",
-    "        # No \"tools\" parameter = no grounding\n",
-    "        \"generationConfig\": {\n",
-    "            \"temperature\": 0.2\n",
-    "        }\n",
-    "    }\n",
-    "    \n",
-    "    response = requests.post(\n",
-    "        url,\n",
-    "        headers={\n",
-    "            \"Authorization\": f\"Bearer {get_access_token()}\",\n",
-    "            \"Content-Type\": \"application/json\",\n",
-    "        },\n",
-    "        json=request_body,\n",
-    "        timeout=120,\n",
-    "    )\n",
-    "    response.raise_for_status()\n",
-    "    return response.json()\n",
-    "\n",
-    "print(\"Functions defined\")"
-   ]
+   "outputs": [],
+   "source": "def get_access_token():\n    \"\"\"Get a Google Cloud access token for API authentication.\"\"\"\n    credentials, _ = google.auth.default()\n    auth_req = google.auth.transport.requests.Request()\n    credentials.refresh(auth_req)\n    return credentials.token\n\n\ndef generate_with_grounding(prompt: str, model_id: str = \"gemini-2.5-flash\") -> dict:\n    \"\"\"\n    Call Vertex AI Gemini with Parallel web search grounding.\n\n    Args:\n        prompt: The question to ask\n        model_id: Which Gemini model to use\n\n    Returns:\n        The raw API response as a dictionary\n    \"\"\"\n    # Build the API endpoint URL\n    url = f\"https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{model_id}:generateContent\"\n\n    # Build the request body\n    request_body = {\n        \"contents\": [\n            {\n                \"role\": \"user\",\n                \"parts\": [{\"text\": prompt}]\n            }\n        ],\n        # This is the key part - adding the grounding tool.\n        # Passes PARALLEL_API_KEY when set (BYOK) or omits it (Marketplace).\n        \"tools\": [build_grounding_config(PARALLEL_API_KEY)],\n        \"generationConfig\": {\n            \"temperature\": 0.2\n        }\n    }\n\n    # Make the API call\n    response = requests.post(\n        url,\n        headers={\n            \"Authorization\": f\"Bearer {get_access_token()}\",\n            \"Content-Type\": \"application/json\",\n        },\n        json=request_body,\n        timeout=120,\n    )\n    response.raise_for_status()\n    return response.json()\n\n\ndef generate_without_grounding(prompt: str, model_id: str = \"gemini-2.5-flash\") -> dict:\n    \"\"\"\n    Call Vertex AI Gemini WITHOUT grounding (for comparison).\n    \"\"\"\n    url = f\"https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{model_id}:generateContent\"\n\n    request_body = {\n        \"contents\": [\n            {\n                \"role\": \"user\",\n                \"parts\": [{\"text\": prompt}]\n            }\n        ],\n        # No \"tools\" parameter = no grounding\n        \"generationConfig\": {\n            \"temperature\": 0.2\n        }\n    }\n\n    response = requests.post(\n        url,\n        headers={\n            \"Authorization\": f\"Bearer {get_access_token()}\",\n            \"Content-Type\": \"application/json\",\n        },\n        json=request_body,\n        timeout=120,\n    )\n    response.raise_for_status()\n    return response.json()\n\nprint(\"Functions defined\")"
   },
   {
    "cell_type": "markdown",
@@ -237,21 +76,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'raw_response' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 52\u001b[39m\n\u001b[32m     44\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m {\n\u001b[32m     45\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mtext\u001b[39m\u001b[33m\"\u001b[39m: text,\n\u001b[32m     46\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33msources\u001b[39m\u001b[33m\"\u001b[39m: sources,\n\u001b[32m     47\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mqueries\u001b[39m\u001b[33m\"\u001b[39m: queries\n\u001b[32m     48\u001b[39m     }\n\u001b[32m     51\u001b[39m \u001b[38;5;66;03m# Parse our response\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m52\u001b[39m result = parse_grounded_response(\u001b[43mraw_response\u001b[49m)\n\u001b[32m     54\u001b[39m \u001b[38;5;66;03m# Display nicely\u001b[39;00m\n\u001b[32m     55\u001b[39m sources_md = \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m.join([\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m- [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00ms[\u001b[33m'\u001b[39m\u001b[33mtitle\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m](\u001b[39m\u001b[38;5;132;01m{\u001b[39;00ms[\u001b[33m'\u001b[39m\u001b[33muri\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m)\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m result[\u001b[33m\"\u001b[39m\u001b[33msources\u001b[39m\u001b[33m\"\u001b[39m][:\u001b[32m5\u001b[39m]])\n",
-      "\u001b[31mNameError\u001b[39m: name 'raw_response' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def parse_grounded_response(response: dict) -> dict:\n",
     "    \"\"\"\n",
@@ -379,22 +206,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "You've learned:\n",
-    "\n",
-    "1. **Grounding config** - Add `tools: [{\"parallelAiSearch\": {}}]` to your request\n",
-    "2. **Making calls** - Use the standard Vertex AI REST API with the grounding tool\n",
-    "3. **Parsing responses** - Extract text from `candidates[0].content.parts[0].text` and sources from `groundingMetadata.groundingChunks`\n",
-    "4. **Customization** - Use `customConfigs` to filter domains and limit results\n",
-    "\n",
-    "## Next Steps\n",
-    "\n",
-    "- Check out `quickstart.py` for a minimal example using the helper library\n",
-    "- See `demo.py` for a command-line demo\n",
-    "- Read the [Vertex AI documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-parallel) for more options"
-   ]
+   "source": "## Summary\n\nYou've learned:\n\n1. **Grounding config** \u2014 Add `tools: [{\"parallelAiSearch\": {}}]` for Marketplace, or `tools: [{\"parallelAiSearch\": {\"api_key\": \"...\"}}]` for BYOK\n2. **Making calls** \u2014 Use the standard Vertex AI REST API with the grounding tool\n3. **Parsing responses** \u2014 Extract text from `candidates[0].content.parts[0].text` and sources from `groundingMetadata.groundingChunks`\n4. **Customization** \u2014 Use `customConfigs` to filter domains and limit results\n\n## Next Steps\n\n- Check out `quickstart.py` for a minimal example using the helper library\n- See `demo.py` for a command-line demo\n- Read the [Parallel + Vertex AI integration docs](https://docs.parallel.ai/integrations/google-vertex) and Google's [official documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-parallel) for more options"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

The Parallel API key is now **optional** for the Vertex AI demo, supporting both auth paths documented at https://docs.parallel.ai/integrations/google-vertex and https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-parallel:

- **Google Cloud Marketplace** — when a GCP project has an active Parallel Web Search subscription, requests omit the `api_key` field from the `parallelAiSearch` tool spec.
- **Bring Your Own Key (BYOK)** — when `PARALLEL_API_KEY` is set (or `parallel_api_key` is passed), the key is included in each request.

If both are present, the API key takes precedence (per the Parallel integration docs).

## Changes

- `client.py` — `GroundingConfig.api_key` is optional; `to_grounding_spec()` only emits the key when set. `GroundedGeminiClient` and `generate_grounded_response` accept an optional `parallel_api_key` (falls back to env var). `validate_setup` reports the detected auth mode and warns when Marketplace is assumed.
- `__init__.py` — module docstring shows both modes.
- `README.md` — prerequisites, quickstart, usage examples, env var table, and troubleshooting cover both modes.
- `.env.example` — documents both options; `PARALLEL_API_KEY` is commented out.
- `demo.py` — prints the active auth mode; help text reflects optional `PARALLEL_API_KEY`.
- `quickstart.py` — comments document both paths.
- `tutorial.ipynb` — walks through both modes; helper builds spec with or without the key.
- `tests/test_client.py` — added cases for Marketplace and BYOK request bodies, plus env-var/parameter resolution; existing tests updated.

## Test plan

- [x] `uv run pytest tests/ -v` — 18 tests pass
- [x] `python demo.py --check` with no `PARALLEL_API_KEY` → reports Marketplace mode
- [x] `python demo.py --check` with `PARALLEL_API_KEY` set → reports BYOK mode
- [x] `python quickstart.py` end-to-end in Marketplace mode → grounded answer with sources
- [x] `python quickstart.py` end-to-end in BYOK mode → grounded answer with sources