### PR TITLE
Cookbook refresh: README, CONTRIBUTING, recipe registry

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: pre-commit
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    name: Run all pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so secret scans can see PR commits
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run pre-commit on all files
+        uses: pre-commit/action@v3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,15 @@ venv/
 dist/
 build/
 
-# Environment files
+# Environment files (never commit — use .env.example / .dev.vars.example instead)
 .env
 .env.local
 .env*.local
+.dev.vars
+.dev.vars.local
+
+# Cloudflare Workers build/dev artifacts
+.wrangler/
 
 # Playwright
 .playwright-mcp*

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,18 +1,21 @@
 # Gitleaks config for the Parallel Cookbook.
-# Extends the default ruleset and adds a few Parallel/Cookbook-specific rules.
-# Run locally: `gitleaks detect --staged` (or `--source .` for the full tree).
+# Extends the default ruleset (~150 rules covering AWS/GitHub/Stripe/OpenAI/etc.)
+# with Parallel-specific API key patterns and a small allowlist for the
+# placeholder values our docs use.
+#
+# Run locally: `pre-commit run gitleaks --all-files`
 
 [extend]
 useDefault = true
 
 # ---------------------------------------------------------------------------
-# Custom rules
+# Custom rules — Parallel and partner-provider keys not covered by defaults
 # ---------------------------------------------------------------------------
 
 [[rules]]
 id = "parallel-api-key"
 description = "Parallel API key"
-# Parallel keys observed: ~40-char URL-safe base64-ish; appear after PARALLEL_API_KEY=
+# Parallel keys are 40-char URL-safe strings assigned after PARALLEL_API_KEY=
 regex = '''(?i)PARALLEL_API_KEY\s*=\s*["']?([A-Za-z0-9_\-]{32,})'''
 secretGroup = 1
 keywords = ["parallel_api_key"]
@@ -29,22 +32,8 @@ description = "Groq API key"
 regex = '''gsk_[A-Za-z0-9]{40,}'''
 keywords = ["gsk_"]
 
-[[rules]]
-id = "cloudflare-account-id"
-description = "Cloudflare account_id in wrangler config"
-# 32-char lowercase hex inside a wrangler "account_id" field
-regex = '''"account_id"\s*:\s*"[a-f0-9]{32}"'''
-keywords = ["account_id"]
-
-[[rules]]
-id = "cloudflare-kv-id-literal"
-description = "Hardcoded Cloudflare KV namespace id (use a placeholder)"
-# Catches a 32-char hex `id` next to a `kv_namespaces` `binding`
-regex = '''"binding"\s*:\s*"[A-Z0-9_]+"\s*,\s*"id"\s*:\s*"[a-f0-9]{32}"'''
-keywords = ["kv_namespaces", "binding"]
-
 # ---------------------------------------------------------------------------
-# Allowlist
+# Allowlist — placeholder values used in docs and .example files
 # ---------------------------------------------------------------------------
 
 [allowlist]
@@ -56,10 +45,8 @@ paths = [
   '''(?i)task-best-practices\.md$''',
 ]
 
-# Common placeholder/example values used in docs and .env.example files.
 regexes = [
   '''your[_-]?(api[_-]?key|parallel[_-]?api[_-]?key|cerebras[_-]?api[_-]?key|groq[_-]?api[_-]?key)''',
   '''<YOUR_[A-Z0-9_]+>''',
   '''(?i)(your-api-key-here|your-parallel-api-key|your-key|api-key-here|placeholder)''',
-  '''csk-[fa-z0-9]{8}\.{3,}''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,65 @@
+# Gitleaks config for the Parallel Cookbook.
+# Extends the default ruleset and adds a few Parallel/Cookbook-specific rules.
+# Run locally: `gitleaks detect --staged` (or `--source .` for the full tree).
+
+[extend]
+useDefault = true
+
+# ---------------------------------------------------------------------------
+# Custom rules
+# ---------------------------------------------------------------------------
+
+[[rules]]
+id = "parallel-api-key"
+description = "Parallel API key"
+# Parallel keys observed: ~40-char URL-safe base64-ish; appear after PARALLEL_API_KEY=
+regex = '''(?i)PARALLEL_API_KEY\s*=\s*["']?([A-Za-z0-9_\-]{32,})'''
+secretGroup = 1
+keywords = ["parallel_api_key"]
+
+[[rules]]
+id = "cerebras-api-key"
+description = "Cerebras API key"
+regex = '''csk-[a-z0-9]{40,}'''
+keywords = ["csk-"]
+
+[[rules]]
+id = "groq-api-key"
+description = "Groq API key"
+regex = '''gsk_[A-Za-z0-9]{40,}'''
+keywords = ["gsk_"]
+
+[[rules]]
+id = "cloudflare-account-id"
+description = "Cloudflare account_id in wrangler config"
+# 32-char lowercase hex inside a wrangler "account_id" field
+regex = '''"account_id"\s*:\s*"[a-f0-9]{32}"'''
+keywords = ["account_id"]
+
+[[rules]]
+id = "cloudflare-kv-id-literal"
+description = "Hardcoded Cloudflare KV namespace id (use a placeholder)"
+# Catches a 32-char hex `id` next to a `kv_namespaces` `binding`
+regex = '''"binding"\s*:\s*"[A-Z0-9_]+"\s*,\s*"id"\s*:\s*"[a-f0-9]{32}"'''
+keywords = ["kv_namespaces", "binding"]
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+[allowlist]
+description = "Documentation, placeholders, and known-safe matches"
+
+paths = [
+  '''(?i)\.example$''',
+  '''(?i)\.gitleaks\.toml$''',
+  '''(?i)task-best-practices\.md$''',
+]
+
+# Common placeholder/example values used in docs and .env.example files.
+regexes = [
+  '''your[_-]?(api[_-]?key|parallel[_-]?api[_-]?key|cerebras[_-]?api[_-]?key|groq[_-]?api[_-]?key)''',
+  '''<YOUR_[A-Z0-9_]+>''',
+  '''(?i)(your-api-key-here|your-parallel-api-key|your-key|api-key-here|placeholder)''',
+  '''csk-[fa-z0-9]{8}\.{3,}''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Run these checks before every commit. Install once per clone:
+#   brew install pre-commit   # or: pip install pre-commit
+#   pre-commit install
+#
+# The same hooks run in CI via .github/workflows/pre-commit.yml, so what
+# passes locally passes there.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+
+  # Secret / sensitive-ID scanning (uses .gitleaks.toml)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # Block committing real .env / .dev.vars files (any non-.example variant)
+  - repo: local
+    hooks:
+      - id: forbid-env-files
+        name: Refuse to commit .env / .dev.vars (use .example variants instead)
+        entry: "Commit blocked: do not commit .env or .dev.vars files. Use the .example variant for documentation."
+        language: fail
+        files: '(?:^|/)(\.env(\..+)?|\.dev\.vars(\..+)?)$'
+        exclude: '\.example$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,153 @@
-Please talk to https://x.com/janwilmake
+# Contributing to the Parallel Cookbook
+
+Thanks for considering a contribution. The cookbook exists to help developers ship with [Parallel](https://parallel.ai) faster — every recipe should leave a builder thinking *"I could fork this today."*
+
+There are three ways to contribute:
+
+1. **[Submit a recipe](#submitting-a-recipe)** to live in this repo
+2. **[Submit a community example](#submitting-a-community-example)** that lives in your own repo
+3. **[Improve the cookbook itself](#improving-the-cookbook)** — docs, organization, the website
+
+For anything not covered here, open an [issue](https://github.com/parallel-web/parallel-cookbook/issues) or DM [@p0](https://x.com/p0).
+
+---
+
+## Submitting a Recipe
+
+A recipe is a self-contained working application with a live demo and a clear pedagogical point. Every recipe in the cookbook should answer *"why would someone copy this?"* in one sentence.
+
+### What makes a good recipe
+
+| ✅ Good | ❌ Avoid |
+| --- | --- |
+| Solves one specific problem (e.g. "stream Task progress to a UI") | Tries to demo every Parallel API at once (templates are the exception) |
+| Shipped with a live demo URL | Local-only with no deploy story |
+| Has a one-click deploy button or `DEPLOY.md` | Requires hand-rolling infra to try it |
+| Real research/data domain (companies, papers, news) | "Hello world" toy data |
+| README explains the *design decisions*, not just setup | README is just `npm install && npm run dev` |
+| Uses our latest API surfaces (Search, Extract, Task SSE, Ingest) | Wraps deprecated endpoints |
+
+### Folder structure
+
+Pick a top-level home based on language:
+
+```
+typescript-recipes/<your-recipe-name>/
+python-recipes/<your-recipe-name>/
+```
+
+Use kebab-case directories prefixed with `parallel-` (e.g. `parallel-fact-checker-cerebras`). Inside the recipe folder include at minimum:
+
+```
+<your-recipe-name>/
+├── README.md             # Required — see template below
+├── .env.example          # Required if the recipe needs secrets
+├── package.json          # Or pyproject.toml / requirements.txt
+├── LICENSE               # MIT preferred for parity with the cookbook
+└── ...                   # Your code
+```
+
+If your recipe deploys to Cloudflare, Vercel, or Supabase, include the appropriate config (`wrangler.jsonc`, `vercel.json`, `supabase/config.toml`).
+
+### README template
+
+Every recipe README should hit these sections, roughly in this order:
+
+```markdown
+# <Recipe Title>
+
+One-sentence pitch. Live demo: <url>
+
+[Deploy button or link to DEPLOY.md]
+
+## What it shows
+- Bullet 1
+- Bullet 2
+
+## Architecture
+ASCII diagram or short prose explaining the request flow.
+
+## Quick Start
+1. Clone
+2. Install
+3. Set env vars
+4. Run
+
+## How it works
+The interesting part — design choices, gotchas, why this approach.
+
+## License
+MIT (or whatever you chose)
+```
+
+The [Vercel Template README](typescript-recipes/parallel-vercel-template/README.md) is a good reference.
+
+### Register the recipe
+
+After your recipe is in place, add an entry to two places so it shows up everywhere:
+
+1. **[`README.md`](README.md)** — add a row under the most appropriate category. If no category fits, propose a new one.
+2. **[`website/cookbook.json`](website/cookbook.json)** — add an entry following [`cookbook.schema.json`](website/cookbook.schema.json). Fields:
+
+   ```json
+   {
+     "slug": "your-recipe-name",
+     "popular": false,
+     "featured": false,
+     "title": "Display Title",
+     "description": "One-sentence description.",
+     "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/your-recipe-name",
+     "websiteUrl": "https://your-demo.example.com",
+     "creators": ["yourgithub"],
+     "imageUrl": "https://svg.quickog.com/https://your-demo.example.com/og.svg",
+     "tags": ["task", "sse", "cloudflare"]
+   }
+   ```
+
+   Reviewers set `featured` / `popular`.
+
+### Tags
+
+Use lowercase, hyphenated tags drawn from this controlled vocabulary so filters on [p0web.com](https://p0web.com) stay clean:
+
+- **API surface**: `search`, `extract`, `task`, `deep-research`, `ingest`, `mcp`, `webhooks`, `sse`, `oauth`
+- **Stack**: `cloudflare`, `vercel`, `nextjs`, `supabase`, `vertex-ai`, `python`, `typescript`, `temporal`
+- **Pattern**: `agent`, `enrichment`, `monitoring`, `realtime`, `batch`, `fact-checking`, `template`, `entity-resolution`
+
+Propose new tags in your PR if none of these fit.
+
+### Quality bar
+
+Before opening a PR, double-check:
+
+- [ ] Recipe runs end-to-end from a fresh clone using only the README
+- [ ] Live demo URL is reachable and shows what the README claims
+- [ ] No API keys, secrets, or `.env` files committed (use `.env.example`)
+- [ ] Lockfile committed (`package-lock.json`, `pnpm-lock.yaml`, or `uv.lock`)
+- [ ] LICENSE included (MIT preferred)
+- [ ] Title and description fit on one line each
+- [ ] Recipe added to **both** `README.md` and `website/cookbook.json`
+
+---
+
+## Submitting a Community Example
+
+If your project lives in your own repo and you'd rather keep it there, that's perfect — open a PR adding a row to the **Community Examples** table in [`README.md`](README.md) and an entry to [`website/cookbook.json`](website/cookbook.json) (omit the `repoUrl` pointing into this repo; use yours).
+
+We'll feature standout community projects on the website.
+
+---
+
+## Improving the Cookbook
+
+Documentation, organization, the [`p0web.com`](https://p0web.com) site, and the [`task-best-practices.md`](task-best-practices.md) guide are all fair game for PRs. For larger reorgs (new top-level categories, folder moves), open an issue first so we can align before you build.
+
+## Code of Conduct
+
+Be kind, give credit, and credit others' work properly. Recipes shouldn't include scraped private data, copyrighted media, or content that violates a source's terms of service. If you're unsure, ask in your PR.
+
+## Questions
+
+- Open an [issue](https://github.com/parallel-web/parallel-cookbook/issues)
+- DM [@p0](https://x.com/p0) on X
+- Email hello@parallel.ai

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,13 +141,15 @@ brew install pre-commit   # or: pip install pre-commit
 pre-commit install
 ```
 
-What's enforced (see [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for the full list):
+What's enforced (see [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for the exact list):
 
-- **Secret scanning** via [gitleaks](https://github.com/gitleaks/gitleaks) using [`.gitleaks.toml`](.gitleaks.toml) — blocks Parallel/Cerebras/Groq API keys, Cloudflare account IDs, and hardcoded KV namespace IDs.
-- **Refuse to commit `.env` / `.dev.vars` files** (use `.example` variants instead).
-- JSON/YAML syntax validation, trailing-whitespace, end-of-file, large-file, merge-conflict-marker, private-key detection.
+- **`detect-private-key`** — blocks SSH/RSA/EC/OpenSSH private keys.
+- **`gitleaks`** — secret scanning using [`.gitleaks.toml`](.gitleaks.toml). Inherits ~150 default rules (AWS/GitHub/Stripe/OpenAI/etc.) and adds custom rules for Parallel, Cerebras, and Groq API keys. Allowlists placeholder strings like `your-api-key-here` and `<YOUR_API_KEY>`.
+- **`forbid-env-files`** — refuses to commit `.env` or `.dev.vars` files (use the `.example` variant instead).
 
 False positive? Add an entry to the `[allowlist]` section of `.gitleaks.toml` and explain why in the PR.
+
+> Note on Cloudflare IDs: `account_id` and KV namespace IDs are public identifiers, not secrets — but please use `<YOUR_KV_NAMESPACE_ID>` placeholders in committed `wrangler.jsonc` files anyway, so recipes are portable for forks. This is a code-review check, not enforced by the scanner.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,11 +122,32 @@ Before opening a PR, double-check:
 
 - [ ] Recipe runs end-to-end from a fresh clone using only the README
 - [ ] Live demo URL is reachable and shows what the README claims
-- [ ] No API keys, secrets, or `.env` files committed (use `.env.example`)
+- [ ] No API keys, secrets, or `.env` / `.dev.vars` files committed (use `.example` variants)
+- [ ] No hardcoded Cloudflare account IDs or KV namespace IDs — use `<YOUR_KV_NAMESPACE_ID>` placeholders and document `wrangler kv:namespace create` in the README
+- [ ] Production-only routes live under `env.production` in `wrangler.jsonc`, not the default config
 - [ ] Lockfile committed (`package-lock.json`, `pnpm-lock.yaml`, or `uv.lock`)
 - [ ] LICENSE included (MIT preferred)
 - [ ] Title and description fit on one line each
 - [ ] Recipe added to **both** `README.md` and `website/cookbook.json`
+
+### Enable pre-commit
+
+The repo uses [pre-commit](https://pre-commit.com) to scan for secrets, infra IDs, and basic hygiene before every commit. The exact same hooks run in CI via [`.github/workflows/pre-commit.yml`](.github/workflows/pre-commit.yml), so what passes locally passes in CI.
+
+Set up once per clone:
+
+```bash
+brew install pre-commit   # or: pip install pre-commit
+pre-commit install
+```
+
+What's enforced (see [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for the full list):
+
+- **Secret scanning** via [gitleaks](https://github.com/gitleaks/gitleaks) using [`.gitleaks.toml`](.gitleaks.toml) — blocks Parallel/Cerebras/Groq API keys, Cloudflare account IDs, and hardcoded KV namespace IDs.
+- **Refuse to commit `.env` / `.dev.vars` files** (use `.example` variants instead).
+- JSON/YAML syntax validation, trailing-whitespace, end-of-file, large-file, merge-conflict-marker, private-key detection.
+
+False positive? Add an entry to the `[allowlist]` section of `.gitleaks.toml` and explain why in the PR.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ After your recipe is in place, add an entry to two places so it shows up everywh
 
 ### Tags
 
-Use lowercase, hyphenated tags drawn from this controlled vocabulary so filters on [p0web.com](https://p0web.com) stay clean:
+Use lowercase, hyphenated tags drawn from this controlled vocabulary so filters stay clean:
 
 - **API surface**: `search`, `extract`, `task`, `deep-research`, `ingest`, `mcp`, `webhooks`, `sse`, `oauth`
 - **Stack**: `cloudflare`, `vercel`, `nextjs`, `supabase`, `vertex-ai`, `python`, `typescript`, `temporal`
@@ -140,7 +140,7 @@ We'll feature standout community projects on the website.
 
 ## Improving the Cookbook
 
-Documentation, organization, the [`p0web.com`](https://p0web.com) site, and the [`task-best-practices.md`](task-best-practices.md) guide are all fair game for PRs. For larger reorgs (new top-level categories, folder moves), open an issue first so we can align before you build.
+Documentation, organization, the [`website/`](website/) sources, and the [`task-best-practices.md`](task-best-practices.md) guide are all fair game for PRs. For larger reorgs (new top-level categories, folder moves), open an issue first so we can align before you build.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,186 @@
+<div align="center">
+
 # Parallel Cookbook
 
-The following cookbook is designed to get you building with Parallel APIs as quickly as possible. Explore and remix recipes and OSS projects using Parallel, use useful utilities, and try the machine quickstart to get cooking immediately.
+**Full-stack recipes, examples, and templates for building with the [Parallel Web APIs](https://docs.parallel.ai).**
 
-## Recipes & Examples
+[Docs](https://docs.parallel.ai) · [Live Cookbook](https://p0web.com) · [API Reference](https://docs.parallel.ai/api-reference) · [@p0](https://x.com/p0)
 
-| Title                           | Description                              | Code                                                                                                        | Demo                                                                                   |
-| ------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Data Enrichment with Supabase   | Real-time enrichment with Edge Functions | [Recipe](typescript-recipes/parallel-supabase-enrichment)                                                   | -                                                                                      |
-| Tasks Playground with Streaming | Using Durable Objects and SSE Events API | [Recipe](https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-tasks-sse) | [oss.parallel.ai/tasks-sse](https://oss.parallel.ai/tasks-sse/)                        |
-| Market Analysis Demo            | Deep Research for Market Analysis        | [App Repo](https://github.com/parallel-web/parallel-cookbook/tree/main/python-recipes/market-analysis-demo)                                                                                                 | [market-analysis-demo.parallel.ai](https://market-analysis-demo.parallel.ai/)          |
-| Search Agent                    | AI SDK + Parallel SDK Search API as tool | [Recipe](typescript-recipes/parallel-search-agent)                                                          | [oss.parallel.ai/agent](https://oss.parallel.ai/agent)                                 |
-| Competitive Analysis            | Using Web Enrichment and Reddit MCP      | [App Repo](https://github.com/parallel-web/competitive-analysis-demo/tree/main)                             | [competitive-analsis-demo.parallel.ai](https://competitive-analysis-demo.parallel.ai/) |
+</div>
+
+---
+
+The Parallel Cookbook is a curated set of recipes that show how to build real applications on Parallel's web research stack — **Search**, **Extract**, **Task**, **Ingest**, and **MCP**. Each recipe is a working app with a live demo, a deploy button, and prose that explains the design decisions.
+
+> **New here?** Start with the [Vercel Template](typescript-recipes/parallel-vercel-template) (TypeScript) or the [Deep Research notebook](python-recipes/Deep_Research_Recipe.ipynb) (Python) for an end-to-end tour of the platform.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Recipes by Category](#recipes-by-category)
+  - [Templates & Starters](#templates--starters)
+  - [Agents & Search](#agents--search)
+  - [Data Enrichment](#data-enrichment)
+  - [Realtime Streaming (SSE)](#realtime-streaming-sse)
+  - [Scheduled Research & Webhooks](#scheduled-research--webhooks)
+  - [Deep Research & Notebooks](#deep-research--notebooks)
+  - [Identity & Entity Resolution](#identity--entity-resolution)
+  - [Fact Checking](#fact-checking)
+  - [Cloud Provider Integrations](#cloud-provider-integrations)
+- [Community Examples](#community-examples)
+- [Resources & Utilities](#resources--utilities)
+- [Machine Quickstart (MCP)](#machine-quickstart-mcp)
+- [Contributing](#contributing)
+
+## Quick Start
+
+Get an API key at [platform.parallel.ai](https://platform.parallel.ai), then pick your stack.
+
+**TypeScript / Node**
+
+```bash
+npm install parallel-web
+```
+
+```ts
+import Parallel from "parallel-web";
+const client = new Parallel({ apiKey: process.env.PARALLEL_API_KEY });
+
+const result = await client.beta.search({
+  objective: "Find the latest funding round announcements for AI startups in 2026",
+});
+console.log(result.results);
+```
+
+**Python**
+
+```bash
+pip install parallel-web
+```
+
+```python
+from parallel import Parallel
+client = Parallel()  # reads PARALLEL_API_KEY from env
+
+run = client.task_run.create(
+    input="What is the latest revenue figure for Anthropic?",
+    processor="core",
+)
+print(run.output)
+```
+
+## Recipes by Category
+
+Every recipe in this repo is listed below, grouped by what you're trying to build. Looking for a specific API surface? Search for the badge — `Search`, `Extract`, `Task`, `SSE`, `Webhooks`, `MCP`, `OAuth`, `Ingest`.
+
+### Templates & Starters
+
+Multi-API starter projects — fork these first.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Vercel Template**](typescript-recipes/parallel-vercel-template) | Next.js demo of Search + Extract + Tasks with SSE in a single app. Includes Vercel marketplace integration for one-click API key. | `Search` `Extract` `Task` `SSE` | Next.js · Vercel | [Live](https://parallel-vercel-template-cookbook.vercel.app/) · [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fparallel-web%2Fparallel-cookbook%2Ftree%2Fmain%2Ftypescript-recipes%2Fparallel-vercel-template&project-name=parallel-vercel-template&repository-name=parallel-vercel-template&integration-ids=oac_qjiYAM8BTtX0UDS6HEPY97nU) |
+
+### Agents & Search
+
+LLM agents that use Parallel's Search API as a tool with the Vercel AI SDK.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Search Agent (Cerebras)**](typescript-recipes/parallel-search-agent-cerebras) | Multi-turn web research agent backed by Cerebras (GPT-OSS / Qwen). Iterative multi-angle searches, full-stack with vanilla JS frontend. | `Search` | Cloudflare Workers · Cerebras · AI SDK | [Live](https://oss.parallel.ai/agent/) |
+| [**Search Agent (Groq)**](typescript-recipes/parallel-search-agent-groq) | Same agent shape, Llama 4 Maverick on Groq with 128k context for long sessions. | `Search` | Cloudflare Workers · Groq · AI SDK | [Live](https://oss.parallel.ai/agent/) |
+
+### Data Enrichment
+
+Take a thin input (a name, a domain) and return structured, cited fields.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Supabase Enrichment**](typescript-recipes/parallel-supabase-enrichment) | Real-time enrichment pipeline — INSERT a company, an Edge Function fires a Task, results stream back via Supabase Realtime. | `Task` `Webhooks` | Next.js · Supabase Edge Functions · Postgres | – |
+| [**Large-Scale Tasks**](python-recipes/Large_Scale_Tasks_Recipe.py) | Production batch script for 1k+ row CSVs — three-stage enqueue → fetch → merge with retry, dry-run, and idempotent state. | `Task Group` | Python | – |
+| [**Task Group + Temporal**](python-recipes/Task_Group_Temporal_Recipe.py) | Combine Task Groups with Temporal workflow orchestration for enterprise-grade durability. | `Task Group` | Python · Temporal | – |
+
+### Realtime Streaming (SSE)
+
+Stream task progress to a UI in real time.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Tasks Playground (SSE)**](typescript-recipes/parallel-tasks-sse) | Full-featured task manager that exercises every processor (lite → ultra8x) with live SSE events. OAuth 2.1 with PKCE & dynamic client registration. | `Task` `SSE` `OAuth` | Cloudflare Workers · Durable Objects | [Live](https://oss.parallel.ai/tasks-sse/) |
+
+### Scheduled Research & Webhooks
+
+Recurring research, cron jobs, and webhook delivery.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Daily Insights**](typescript-recipes/parallel-daily-insights) | Cron-triggered daily research feed — runs Tasks on a schedule, persists to KV, publishes a public data feed. Includes a `SPEC.md` showing the task spec used. | `Task` `Webhooks` `Cron` | Cloudflare Workers · KV | [Live](https://daily.p0web.com) |
+
+### Deep Research & Notebooks
+
+Long-running, exploratory research with structured outputs and citations.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Market Analysis Demo**](python-recipes/market-analysis-demo) | Flask app that turns a market-research prompt into a streamed report with email delivery. SSE progress + webhook completion. | `Task` `Deep Research` `SSE` `Webhooks` | Python · Flask · Postgres · Resend | [Live](https://market-analysis-demo.parallel.ai) |
+| [**Deep Research Notebook**](python-recipes/Deep_Research_Recipe.ipynb) | Interactive Jupyter walkthrough of Deep Research — text + JSON outputs, citations, confidence scores, webhook patterns. | `Deep Research` `Webhooks` | Jupyter · Python | – |
+
+### Identity & Entity Resolution
+
+Matching real-world entities across sources.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Entity Resolution**](typescript-recipes/parallel-entity-resolution) | Find every social profile for a single person across platforms in one Task. | `Task` `OAuth` | Cloudflare Workers | [Live](https://entity-resolution-demo.parallel.ai) |
+
+### Fact Checking
+
+Claim extraction + verification with cited evidence.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Fact Checker (Cerebras)**](typescript-recipes/parallel-fact-checker-cerebras) | Extracts claims from a passage, runs Search per claim, streams verdicts in real time. | `Search` `Extract` | Cloudflare Workers · Cerebras · AI SDK | – |
+
+### Cloud Provider Integrations
+
+How Parallel composes with cloud AI platforms.
+
+| Recipe | Description | APIs | Stack | Demo |
+| --- | --- | --- | --- | --- |
+| [**Vertex AI Grounding**](python-recipes/vertex_ai_demo) | Ground Gemini on Vertex AI with the Parallel Search API for current, cited responses. Supports both GCP Marketplace and BYOK auth. | `Search` | Python · Google Vertex AI | – |
+| [**Competitive Analysis**](https://github.com/parallel-web/competitive-analysis-demo) | Web Enrichment + Reddit MCP combined to produce competitive briefs. | `Task` `MCP` | Python | [Live](https://competitive-analysis-demo.parallel.ai/) |
 
 ## Community Examples
 
-- [Parallel Spreadsheet](https://github.com/zahidkhawaja/parallel-spreadsheet) by [@chillzaza\_](https://x.com/chillzaza_/status/1958005876918292941) (Vercel, Typescript)
-- [Based People](https://github.com/janwilmake/basedpeople) by [@janwilmake](https://x.com/janwilmake/status/1956061673833300443) (Cloudflare, Typescript)
-- [Scira (10k+ stars)](https://github.com/zaidmukaddam/scira) by [@zaidmukaddam](https://x.com/zaidmukaddam/status/1958583204635439264) (Vercel, Typescript)
+Built something you want featured? [Open a PR](CONTRIBUTING.md).
 
-## Resources & Utitlies
+| Project | Author | Stack |
+| --- | --- | --- |
+| [Parallel Spreadsheet](https://github.com/zahidkhawaja/parallel-spreadsheet) | [@chillzaza_](https://x.com/chillzaza_/status/1958005876918292941) | Next.js · TypeScript |
+| [Scira (10k+ ⭐)](https://github.com/zaidmukaddam/scira) | [@zaidmukaddam](https://x.com/zaidmukaddam/status/1958583204635439264) | Next.js · Vercel |
+| [Based People](https://github.com/janwilmake/basedpeople) | [@janwilmake](https://github.com/janwilmake) | Cloudflare Workers · TypeScript |
+| [Tasks via MCP + OAuth](https://github.com/janwilmake/universal-mcp-oauth/tree/main/examples/parallel-tool-calling) | [@janwilmake](https://github.com/janwilmake) | Cloudflare Workers · TypeScript |
 
-- https://github.com/janwilmake/parallel-flatten - Utility for getting flat outputs for easier rendering
+## Resources & Utilities
+
+- **[Task Best Practices](task-best-practices.md)** — schema design, processor selection, common pitfalls, source policy.
+- **[ADR](ADR.md)** — architectural decisions made while building this cookbook.
+- **[task_library_trimmed.json](task_library_trimmed.json)** — curated example task specs for the MCP quickstart below.
+- **[typescript-sdk-types.d.ts](typescript-sdk-types.d.ts)** — flattened TypeScript SDK types, useful for ingesting into LLM context.
+- **[parallel-flatten](https://github.com/janwilmake/parallel-flatten)** — community utility for flattening Task outputs for easier rendering.
+
+## Machine Quickstart (MCP)
+
+The fastest way to get an LLM building with Parallel is to clone this repo and install [our MCPs](https://docs.parallel.ai/integrations/mcp/getting-started). The **llms.txt MCP** is ideal for asking questions about Parallel — it has full context. The other MCPs let you experiment with our APIs without writing code.
 
 ## Contributing
 
-Built something with Parallel APIs you want to showcase? The Parallel cookbook welcomes community contributions. Also ideas for other recipes are welcome. See [contributing](CONTRIBUTING.md) for more details.
+Built something with Parallel? Got an idea for a recipe? See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the submission guide. Quick recipe ideas, design suggestions, and bug reports are welcome as [issues](https://github.com/parallel-web/parallel-cookbook/issues).
 
-## Machine Quickstart
+---
 
-For the quickest way to get started, we recommend cloning this repo and installing [our MCPs](https://docs.parallel.ai/integrations/mcp/getting-started). In particular, the "llms.txt MCP" is perfect to ask questions about parallel as it will provide the most comprehesive answers because it has easy access to all needed context. The other MCPs are a great way to experiment with our APIs without any coding required.
+<div align="center">
+
+Made with [Parallel](https://parallel.ai) · [Docs](https://docs.parallel.ai) · [@p0](https://x.com/p0)
+
+</div>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Full-stack recipes, examples, and templates for building with the [Parallel Web APIs](https://docs.parallel.ai).**
 
-[Docs](https://docs.parallel.ai) · [Live Cookbook](https://p0web.com) · [API Reference](https://docs.parallel.ai/api-reference) · [@p0](https://x.com/p0)
+[Docs](https://docs.parallel.ai) · [API Reference](https://docs.parallel.ai/api-reference) · [Platform](https://platform.parallel.ai) · [@p0](https://x.com/p0)
 
 </div>
 
@@ -114,7 +114,7 @@ Recurring research, cron jobs, and webhook delivery.
 
 | Recipe | Description | APIs | Stack | Demo |
 | --- | --- | --- | --- | --- |
-| [**Daily Insights**](typescript-recipes/parallel-daily-insights) | Cron-triggered daily research feed — runs Tasks on a schedule, persists to KV, publishes a public data feed. Includes a `SPEC.md` showing the task spec used. | `Task` `Webhooks` `Cron` | Cloudflare Workers · KV | [Live](https://daily.p0web.com) |
+| [**Daily Insights**](typescript-recipes/parallel-daily-insights) | Cron-triggered daily research feed — runs Tasks on a schedule, persists to KV, publishes a public data feed. Includes a `SPEC.md` showing the task spec used. | `Task` `Webhooks` `Cron` | Cloudflare Workers · KV | – |
 
 ### Deep Research & Notebooks
 

--- a/oss/wrangler.jsonc
+++ b/oss/wrangler.jsonc
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/wrangler@latest/config-schema.json",
   "name": "parallel-oss-redirect",
-  "account_id": "aceab98f1a2fc658ed4e20bc307fa65a",
   "compatibility_date": "2025-09-11",
   "assets": { "directory": "./" },
   "routes": [

--- a/typescript-recipes/parallel-daily-insights/README.md
+++ b/typescript-recipes/parallel-daily-insights/README.md
@@ -24,4 +24,4 @@ Another mistake it made is thinking it could request a lot of scattered informat
 
 ## Result
 
-You can see the result at https://daily.p0web.com. The task specification has gone through a few iterations to improve confidence — see the [SPEC.md](./SPEC.md) for the current version.
+The task specification has gone through a few iterations to improve confidence — see the [SPEC.md](./SPEC.md) for the current version.

--- a/typescript-recipes/parallel-daily-insights/README.md
+++ b/typescript-recipes/parallel-daily-insights/README.md
@@ -24,6 +24,4 @@ Another mistake it made is thinking it could request a lot of scattered informat
 
 ## Result
 
-You can see the result at https://daily.p0web.com. After the 25th of august 2025 the results should be better due to improved task specification and schedule. I also added a [remix button](https://github.com/janwilmake/forgithub.remix) button in the bottom corner that allows easily giving this worker your own twist. Clicking this button will take the spec allow you to generate a variation of it. Give it a spin! You can see my previous generation [here](https://letmeprompt.com/recurring-tasks-us-b0nl4w0)
-
-[![](https://remix.forgithub.com/badge)](https://remix.forgithub.com/janwilmake/parallel-daily-insights)
+You can see the result at https://daily.p0web.com. The task specification has gone through a few iterations to improve confidence — see the [SPEC.md](./SPEC.md) for the current version.

--- a/typescript-recipes/parallel-daily-insights/README.md
+++ b/typescript-recipes/parallel-daily-insights/README.md
@@ -25,3 +25,19 @@ Another mistake it made is thinking it could request a lot of scattered informat
 ## Result
 
 The task specification has gone through a few iterations to improve confidence — see the [SPEC.md](./SPEC.md) for the current version.
+
+## Deploy
+
+```bash
+# 1. Create a KV namespace and copy the returned id into wrangler.jsonc
+wrangler kv:namespace create DAILY_INSIGHTS
+
+# 2. Set secrets (Parallel API key + a webhook signing secret you choose)
+wrangler secret put PARALLEL_API_KEY
+wrangler secret put PARALLEL_WEBHOOK_SECRET
+
+# 3. After `wrangler deploy`, set WEBHOOK_BASE_URL to the deployed URL
+wrangler secret put WEBHOOK_BASE_URL   # e.g. https://parallel-daily-insights.your-subdomain.workers.dev
+```
+
+To bind to a custom domain, add a `routes` entry to `wrangler.jsonc` or pass `--route` to `wrangler deploy`.

--- a/typescript-recipes/parallel-daily-insights/SPEC.md
+++ b/typescript-recipes/parallel-daily-insights/SPEC.md
@@ -33,7 +33,7 @@ Recurring Tasks Using cronjobs and KV
 
 - List all tasks on homepage in html stuyled with the styleguide
 - Links of tasks go to `/{slug}`
-- Styleguide: https://assets.p0web.com/llms.txt
+- Styleguide: https://assets.parallel.ai/llms.txt
 - Use CSS to adjust theme based on system theme
 - Add gh icon that links to https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights
 - Use parallel icon and logo.

--- a/typescript-recipes/parallel-daily-insights/SPEC.md
+++ b/typescript-recipes/parallel-daily-insights/SPEC.md
@@ -35,7 +35,7 @@ Recurring Tasks Using cronjobs and KV
 - Links of tasks go to `/{slug}`
 - Styleguide: https://assets.p0web.com/llms.txt
 - Use CSS to adjust theme based on system theme
-- Add gh icon that links to https://github.com/janwilmake/parallel-daily-insights
+- Add gh icon that links to https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights
 - Use parallel icon and logo.
 
 `feed.html`:

--- a/typescript-recipes/parallel-daily-insights/public/feed.html
+++ b/typescript-recipes/parallel-daily-insights/public/feed.html
@@ -63,7 +63,7 @@
                         alt="Parallel">
                     <span class="font-mono text-neural">← Back to all insights</span>
                 </a>
-                <a href="https://github.com/janwilmake/parallel-daily-insights"
+                <a href="https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights"
                     class="p-2 hover:bg-neural/10 rounded-lg transition-colors">
                     <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24">
                         <path

--- a/typescript-recipes/parallel-daily-insights/public/feed.html
+++ b/typescript-recipes/parallel-daily-insights/public/feed.html
@@ -28,25 +28,25 @@
     <style>
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2');
             font-weight: normal;
         }
 
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Medium.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Medium.woff2') format('woff2');
             font-weight: 500;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammRegular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2') format('woff2');
             font-weight: normal;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammMedium.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammMedium.woff2') format('woff2');
             font-weight: 500;
         }
     </style>
@@ -57,9 +57,9 @@
         <header class="mb-12">
             <div class="flex items-center justify-between mb-6">
                 <a href="/" class="flex items-center space-x-3 hover:opacity-80 transition-opacity">
-                    <img src="https://assets.p0web.com/dark-parallel-symbol-270.svg" class="w-8 h-8 dark:hidden"
+                    <img src="https://assets.parallel.ai/dark-parallel-symbol-270.svg" class="w-8 h-8 dark:hidden"
                         alt="Parallel">
-                    <img src="https://assets.p0web.com/white-parallel-symbol-270.svg" class="w-8 h-8 hidden dark:block"
+                    <img src="https://assets.parallel.ai/white-parallel-symbol-270.svg" class="w-8 h-8 hidden dark:block"
                         alt="Parallel">
                     <span class="font-mono text-neural">← Back to all insights</span>
                 </a>

--- a/typescript-recipes/parallel-daily-insights/public/home.html
+++ b/typescript-recipes/parallel-daily-insights/public/home.html
@@ -70,7 +70,7 @@
                         </p>
                     </div>
                 </div>
-                <a href="https://github.com/janwilmake/parallel-daily-insights"
+                <a href="https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights"
                     class="p-2 hover:bg-neural/10 rounded-lg transition-colors">
                     <svg class="w-6 h-6 fill-current" viewBox="0 0 24 24">
                         <path

--- a/typescript-recipes/parallel-daily-insights/public/home.html
+++ b/typescript-recipes/parallel-daily-insights/public/home.html
@@ -30,25 +30,25 @@
     <style>
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2');
             font-weight: normal;
         }
 
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Medium.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Medium.woff2') format('woff2');
             font-weight: 500;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammRegular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2') format('woff2');
             font-weight: normal;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammMedium.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammMedium.woff2') format('woff2');
             font-weight: 500;
         }
     </style>
@@ -59,9 +59,9 @@
         <header class="mb-12">
             <div class="flex items-center justify-between mb-8">
                 <div class="flex items-center space-x-4">
-                    <img src="https://assets.p0web.com/dark-parallel-symbol-270.svg" class="w-12 h-12 dark:hidden"
+                    <img src="https://assets.parallel.ai/dark-parallel-symbol-270.svg" class="w-12 h-12 dark:hidden"
                         alt="Parallel">
-                    <img src="https://assets.p0web.com/white-parallel-symbol-270.svg"
+                    <img src="https://assets.parallel.ai/white-parallel-symbol-270.svg"
                         class="w-12 h-12 hidden dark:block" alt="Parallel">
                     <div>
                         <h1 class="text-3xl font-medium">Daily Insights</h1>

--- a/typescript-recipes/parallel-daily-insights/worker.ts
+++ b/typescript-recipes/parallel-daily-insights/worker.ts
@@ -4,6 +4,7 @@
 export interface Env {
   PARALLEL_API_KEY: string;
   PARALLEL_WEBHOOK_SECRET: string;
+  WEBHOOK_BASE_URL: string;
   DAILY_INSIGHTS: KVNamespace;
   ASSETS: Fetcher;
 }
@@ -97,7 +98,7 @@ async function runDailyTasks(env: Env) {
 }
 
 async function createTaskRun(task: Task, env: Env) {
-  const webhookUrl = `https://daily.p0web.com/webhook`;
+  const webhookUrl = `${env.WEBHOOK_BASE_URL}/webhook`;
 
   const response = await fetch("https://api.parallel.ai/v1/tasks/runs", {
     method: "POST",

--- a/typescript-recipes/parallel-daily-insights/wrangler.jsonc
+++ b/typescript-recipes/parallel-daily-insights/wrangler.jsonc
@@ -12,11 +12,11 @@
       "experimental_remote": true
     }
   ],
-  "route": { "custom_domain": true, "pattern": "daily.p0web.com" },
   "triggers": {
     "crons": ["30 23 * * *"]
   },
   "vars": {
-    "ENVIRONMENT": "production"
+    "ENVIRONMENT": "production",
+    "WEBHOOK_BASE_URL": "http://localhost:8787"
   }
 }

--- a/typescript-recipes/parallel-daily-insights/wrangler.jsonc
+++ b/typescript-recipes/parallel-daily-insights/wrangler.jsonc
@@ -5,10 +5,12 @@
   "compatibility_date": "2025-08-14",
   "assets": { "directory": "./public", "binding": "ASSETS" },
   "observability": { "logs": { "enabled": true } },
+  // Create your own KV namespace and replace `id` below:
+  //   wrangler kv:namespace create DAILY_INSIGHTS
   "kv_namespaces": [
     {
       "binding": "DAILY_INSIGHTS",
-      "id": "68b24836e5354bfcbcf43202c65db332",
+      "id": "<YOUR_KV_NAMESPACE_ID>",
       "experimental_remote": true
     }
   ],

--- a/typescript-recipes/parallel-entity-resolution/index.html
+++ b/typescript-recipes/parallel-entity-resolution/index.html
@@ -8,14 +8,14 @@
     <style>
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2');
             font-weight: normal;
             font-style: normal;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammRegular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2') format('woff2');
             font-weight: normal;
             font-style: normal;
         }

--- a/typescript-recipes/parallel-entity-resolution/wrangler.jsonc
+++ b/typescript-recipes/parallel-entity-resolution/wrangler.jsonc
@@ -1,16 +1,19 @@
 {
   "$schema": "https://unpkg.com/wrangler@latest/config-schema.json",
-  "account_id": "aceab98f1a2fc658ed4e20bc307fa65a",
   "name": "entity-resolution-parallel",
   "main": "worker.ts",
   "assets": { "directory": "./" },
   "compatibility_date": "2025-09-27",
   "observability": { "logs": { "enabled": true } },
-  "routes": [
-    {
-      "custom_domain": true,
-      "pattern": "entity-resolution-demo.parallel.ai"
+
+  // To deploy under your own domain, set the route here or via
+  // `wrangler deploy --route yourdomain.com`. Default config has no routes
+  // so `wrangler deploy` won't try to bind to anything you don't own.
+  "env": {
+    "production": {
+      "routes": [
+        { "custom_domain": true, "pattern": "entity-resolution-demo.parallel.ai" }
+      ]
     }
-  ],
-  "env": { "localhost": { "routes": [] } }
+  }
 }

--- a/typescript-recipes/parallel-fact-checker-cerebras/index.html
+++ b/typescript-recipes/parallel-fact-checker-cerebras/index.html
@@ -7,24 +7,24 @@
   <style>
     @font-face {
       font-family: 'FT System Mono';
-      src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2'),
-           url('https://assets.p0web.com/FTSystemMono-Regular.woff') format('woff');
+      src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2'),
+           url('https://assets.parallel.ai/FTSystemMono-Regular.woff') format('woff');
       font-weight: 400;
       font-style: normal;
     }
 
     @font-face {
       font-family: 'FT System Mono';
-      src: url('https://assets.p0web.com/FTSystemMono-Medium.woff2') format('woff2'),
-           url('https://assets.p0web.com/FTSystemMono-Medium.woff') format('woff');
+      src: url('https://assets.parallel.ai/FTSystemMono-Medium.woff2') format('woff2'),
+           url('https://assets.parallel.ai/FTSystemMono-Medium.woff') format('woff');
       font-weight: 500;
       font-style: normal;
     }
 
     @font-face {
       font-family: 'FT System Mono';
-      src: url('https://assets.p0web.com/FTSystemMono-Bold.woff2') format('woff2'),
-           url('https://assets.p0web.com/FTSystemMono-Bold.woff') format('woff');
+      src: url('https://assets.parallel.ai/FTSystemMono-Bold.woff2') format('woff2'),
+           url('https://assets.parallel.ai/FTSystemMono-Bold.woff') format('woff');
       font-weight: 700;
       font-style: normal;
     }
@@ -692,7 +692,7 @@
         </div>
         <div class="parallel-logo">
           <a href="https://parallel.ai">
-            <img src="https://assets.p0web.com/dark-parallel-logo-270.svg" alt="Parallel" class="logo-img">
+            <img src="https://assets.parallel.ai/dark-parallel-logo-270.svg" alt="Parallel" class="logo-img">
           </a>
         </div>
       </div>

--- a/typescript-recipes/parallel-fact-checker-cerebras/wrangler.jsonc
+++ b/typescript-recipes/parallel-fact-checker-cerebras/wrangler.jsonc
@@ -18,16 +18,16 @@
       "persist": true
     }
   },
-  "routes": [
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agents/cerebras-fact-checker",
-      "custom_domain": false
-    },
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agents/cerebras-fact-checker/*",
-      "custom_domain": false
+
+  // To deploy under your own domain, set the route here or via
+  // `wrangler deploy --route yourdomain.com`. Default config has no routes
+  // so `wrangler deploy` won't try to bind to anything you don't own.
+  "env": {
+    "production": {
+      "routes": [
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agents/cerebras-fact-checker", "custom_domain": false },
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agents/cerebras-fact-checker/*", "custom_domain": false }
+      ]
     }
-  ]
+  }
 }

--- a/typescript-recipes/parallel-search-agent-cerebras/SPEC.md
+++ b/typescript-recipes/parallel-search-agent-cerebras/SPEC.md
@@ -1,6 +1,3 @@
-RULES:
-https://uithub.com/janwilmake/gists/tree/main/named-codeblocks.md
-
 PROMPT:
 In this guide, we'll build a Web Research Agent accessible over a simple frontend.
 

--- a/typescript-recipes/parallel-search-agent-cerebras/SPEC.md
+++ b/typescript-recipes/parallel-search-agent-cerebras/SPEC.md
@@ -33,7 +33,7 @@ Please note:
 - No Durable objects needed, just return the text string back from the worker to the html directly
 - Don't use fetch, rather , use search from the parallel-web typescript SDK
 - use CEREBRAS_API_KEY and PARALLEL_API_KEY in .env
-- use https://assets.p0web.com for branding, and cdn.tailwindcss.com for styling
+- use https://assets.parallel.ai for branding, and cdn.tailwindcss.com for styling
 - ensure to define `inputSchema` for the tool, not `parameters`
 - use `createCerebras` with the API key to get a cerebras provider
 - define the HTML in a separate file

--- a/typescript-recipes/parallel-search-agent-cerebras/index.html
+++ b/typescript-recipes/parallel-search-agent-cerebras/index.html
@@ -10,21 +10,21 @@
     <style>
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2');
             font-weight: 400;
             font-display: swap;
         }
 
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Medium.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Medium.woff2') format('woff2');
             font-weight: 500;
             font-display: swap;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammRegular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2') format('woff2');
             font-weight: 400;
             font-display: swap;
         }
@@ -302,7 +302,7 @@
     <div id="app" class="container mx-auto px-2 sm:px-4 py-4 sm:py-8 max-w-4xl">
         <!-- Header -->
         <div class="text-center mb-8 sm:mb-12">
-            <img src="https://assets.p0web.com/dark-parallel-symbol-270.svg" alt="Parallel"
+            <img src="https://assets.parallel.ai/dark-parallel-symbol-270.svg" alt="Parallel"
                 class="mx-auto mb-4 w-12 h-12 sm:w-16 sm:h-16">
             <h1 class="heading-font text-2xl sm:text-4xl font-bold mb-2">Web Search Agent</h1>
             <p class="text-gray-600 text-sm sm:text-base">Powered by Parallel Search API & Cerebras AI</p>

--- a/typescript-recipes/parallel-search-agent-cerebras/worker.ts
+++ b/typescript-recipes/parallel-search-agent-cerebras/worker.ts
@@ -21,7 +21,7 @@ export default {
     const url = new URL(request.url);
 
     if (url.pathname === "/agent" || url.pathname === "/agent/") {
-      // redirect from oss.p0web.com/agent to /agent/ to ensure api call works
+      // redirect /agent → /agents/cerebras-search/ so relative API calls work
       return new Response(null, {
         status: 302,
         headers: { Location: "/agents/cerebras-search/" },

--- a/typescript-recipes/parallel-search-agent-cerebras/wrangler.jsonc
+++ b/typescript-recipes/parallel-search-agent-cerebras/wrangler.jsonc
@@ -4,28 +4,18 @@
   "main": "worker.ts",
   "compatibility_date": "2025-07-14",
   "observability": { "logs": { "enabled": true } },
-  "routes": [
-    // Please note, the more simple setup for a domain looks like this:
-    // {"custom_domain": true,"pattern": "yourdomain.com"}
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agent",
-      "custom_domain": false
-    },
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agent/*",
-      "custom_domain": false
-    },
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agents/cerebras-search",
-      "custom_domain": false
-    },
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agents/cerebras-search/*",
-      "custom_domain": false
+
+  // To deploy under your own domain, set the route here or via
+  // `wrangler deploy --route yourdomain.com`. Default config has no routes
+  // so `wrangler deploy` won't try to bind to anything you don't own.
+  "env": {
+    "production": {
+      "routes": [
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agent", "custom_domain": false },
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agent/*", "custom_domain": false },
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agents/cerebras-search", "custom_domain": false },
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agents/cerebras-search/*", "custom_domain": false }
+      ]
     }
-  ]
+  }
 }

--- a/typescript-recipes/parallel-search-agent-groq/DEPLOY.md
+++ b/typescript-recipes/parallel-search-agent-groq/DEPLOY.md
@@ -1,6 +1,13 @@
 To deploy this on your own Cloudflare account:
 
-1. [Install `wrangler`](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
-2. In [`wrangler.json`](wrangler.json) edit the route to your preferred domain (or remove route property for atomatic wrokers.dev domain assignment)
-3. Gather your Parallel and Groq API Keys into a `.env` file and add these secrets to your worker with `wrangler secret bulk .env`
-4. Deploy using `wrangler deploy`
+1. [Install `wrangler`](https://developers.cloudflare.com/workers/wrangler/install-and-update/) and run `wrangler login`
+2. Create a KV namespace for rate limiting and copy the returned `id` into [`wrangler.jsonc`](wrangler.jsonc):
+   ```bash
+   wrangler kv:namespace create RATE_LIMIT_KV
+   ```
+3. (Optional) Add a `routes` entry to `wrangler.jsonc` if you want to bind a custom domain. Otherwise wrangler assigns a `*.workers.dev` URL.
+4. Gather your Parallel and Groq API keys into a `.env` file and load them as secrets:
+   ```bash
+   wrangler secret bulk .env
+   ```
+5. Deploy: `wrangler deploy`

--- a/typescript-recipes/parallel-search-agent-groq/SPEC.md
+++ b/typescript-recipes/parallel-search-agent-groq/SPEC.md
@@ -1,6 +1,3 @@
-RULES:
-https://uithub.com/janwilmake/gists/tree/main/named-codeblocks.md
-
 PROMPT:
 In this guide, we'll build a Web Research Agent accessible over a simple frontend.
 

--- a/typescript-recipes/parallel-search-agent-groq/SPEC.md
+++ b/typescript-recipes/parallel-search-agent-groq/SPEC.md
@@ -33,7 +33,7 @@ Please note:
 - No Durable objects needed, just return the text string back from the worker to the html directly
 - Don't use fetch, rather , use search from the parallel-web typescript SDK
 - use GROQ_API_KEY and PARALLEL_API_KEY in .env
-- use https://assets.p0web.com for branding, and cdn.tailwindcss.com for styling
+- use https://assets.parallel.ai for branding, and cdn.tailwindcss.com for styling
 - ensure to define `inputSchema` for the tool, not `parameters`
 - use `createGroq` with the API key to get a groq provider
 - define the HTML in a separate file

--- a/typescript-recipes/parallel-search-agent-groq/index.html
+++ b/typescript-recipes/parallel-search-agent-groq/index.html
@@ -13,21 +13,21 @@
     <style>
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2');
             font-weight: 400;
             font-display: swap;
         }
 
         @font-face {
             font-family: 'FT System Mono';
-            src: url('https://assets.p0web.com/FTSystemMono-Medium.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/FTSystemMono-Medium.woff2') format('woff2');
             font-weight: 500;
             font-display: swap;
         }
 
         @font-face {
             font-family: 'Gerstner Programm';
-            src: url('https://assets.p0web.com/Gerstner-ProgrammRegular.woff2') format('woff2');
+            src: url('https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2') format('woff2');
             font-weight: 400;
             font-display: swap;
         }
@@ -397,7 +397,7 @@
     <div id="app" class="container mx-auto px-2 sm:px-4 py-4 sm:py-8 max-w-4xl">
         <!-- Header -->
         <div class="text-center mb-8 sm:mb-12">
-            <img src="https://assets.p0web.com/dark-parallel-symbol-270.svg" alt="Parallel"
+            <img src="https://assets.parallel.ai/dark-parallel-symbol-270.svg" alt="Parallel"
                 class="mx-auto mb-4 w-12 h-12 sm:w-16 sm:h-16">
             <h1 class="heading-font text-2xl sm:text-4xl font-bold mb-2">Web Search Agent</h1>
             <p class="text-light-secondary text-sm sm:text-base">Powered by Parallel Search API & Groq AI</p>

--- a/typescript-recipes/parallel-search-agent-groq/wrangler.jsonc
+++ b/typescript-recipes/parallel-search-agent-groq/wrangler.jsonc
@@ -8,24 +8,25 @@
       "enabled": true
     }
   },
-  "routes": [
-    // Please note, the more simple setup for a domain looks like this:
-    // {"custom_domain": true,"pattern": "yourdomain.com"}
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agents/groq-search",
-      "custom_domain": false
-    },
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/agents/groq-search/*",
-      "custom_domain": false
-    }
-  ],
+
+  // Create your own KV namespace and replace `id` below:
+  //   wrangler kv:namespace create RATE_LIMIT_KV
   "kv_namespaces": [
     {
       "binding": "RATE_LIMIT_KV",
-      "id": "befe4fbf3b1e454799d2e07e5b04a8f4"
+      "id": "<YOUR_KV_NAMESPACE_ID>"
     }
-  ]
+  ],
+
+  // To deploy under your own domain, set the route here or via
+  // `wrangler deploy --route yourdomain.com`. Default config has no routes
+  // so `wrangler deploy` won't try to bind to anything you don't own.
+  "env": {
+    "production": {
+      "routes": [
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agents/groq-search", "custom_domain": false },
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/agents/groq-search/*", "custom_domain": false }
+      ]
+    }
+  }
 }

--- a/typescript-recipes/parallel-search-agent/README.md
+++ b/typescript-recipes/parallel-search-agent/README.md
@@ -1,1 +1,8 @@
-Moved to [parallel-search-agent-cerebras](../parallel-search-agent-cerebras/)
+# Parallel Search Agent
+
+This recipe was split into model-specific variants. Pick the one that fits your use case:
+
+- **[parallel-search-agent-cerebras](../parallel-search-agent-cerebras/)** — Cerebras (GPT-OSS / Qwen). Fastest inference for short-to-medium agent loops.
+- **[parallel-search-agent-groq](../parallel-search-agent-groq/)** — Groq (Llama 4 Maverick, 128k context). Best for long agent sessions.
+
+Both share the same architecture (Cloudflare Worker + Vercel AI SDK + Parallel Search API as a tool) and ship to the same demo at [oss.parallel.ai/agent](https://oss.parallel.ai/agent/).

--- a/typescript-recipes/parallel-tasks-sse/CHANGELOG.md
+++ b/typescript-recipes/parallel-tasks-sse/CHANGELOG.md
@@ -11,7 +11,7 @@
 Context:
 
 - https://uithub.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-tasks-sse
-- https://assets.p0web.com
+- https://assets.parallel.ai
 - https://docs.parallel.ai/api-reference/task-api-v1/stream-task-run-events.md
 - https://docs.parallel.ai/task-api/features/task-sse.md
 

--- a/typescript-recipes/parallel-tasks-sse/SPEC.md
+++ b/typescript-recipes/parallel-tasks-sse/SPEC.md
@@ -1,7 +1,7 @@
 PROMPT:
 https://docs.parallel.ai/api-reference/task-api-v1/create-task-run.md
 https://docs.parallel.ai/api-reference/task-api-v1/stream-task-run-events.md
-https://assets.p0web.com
+https://assets.parallel.ai
 docs: https://pastebin.contextarea.com/e7bqy1n.md
 
 Create a html that:

--- a/typescript-recipes/parallel-tasks-sse/SPEC.md
+++ b/typescript-recipes/parallel-tasks-sse/SPEC.md
@@ -1,11 +1,7 @@
-RULES:
-https://uithub.com/janwilmake/gists/tree/main/named-codeblocks.md
-
 PROMPT:
 https://docs.parallel.ai/api-reference/task-api-v1/create-task-run.md
 https://docs.parallel.ai/api-reference/task-api-v1/stream-task-run-events.md
 https://assets.p0web.com
-https://uithub.com/janwilmake/parallel-mcp/blob/main/parallel-oauth-provider/README.md
 docs: https://pastebin.contextarea.com/e7bqy1n.md
 
 Create a html that:

--- a/typescript-recipes/parallel-tasks-sse/wrangler.jsonc
+++ b/typescript-recipes/parallel-tasks-sse/wrangler.jsonc
@@ -1,23 +1,21 @@
 {
   "$schema": "https://unpkg.com/wrangler@latest/config-schema.json",
   "name": "parallel-tasks-sse",
-  "account_id": "aceab98f1a2fc658ed4e20bc307fa65a",
   "compatibility_date": "2025-07-14",
   "main": "main.ts",
   "assets": { "directory": "./" },
   "observability": { "logs": { "enabled": true } },
-  "routes": [
-    // NB: please note that in several places in the code we assume /tasks-sse/ is the path prefix.
-    // When changing to your own domain, it's adviced to use `custom_domain:true` with a pattern without path, and update the code accordingly so your links don't have this prefix.
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/tasks-sse",
-      "custom_domain": false
-    },
-    {
-      "zone_name": "parallel.ai",
-      "pattern": "oss.parallel.ai/tasks-sse/*",
-      "custom_domain": false
+
+  // NB: this recipe assumes /tasks-sse/ as the path prefix in several places.
+  // To deploy under your own domain: replace `env.production.routes` with a
+  // single `{"custom_domain": true, "pattern": "yourdomain.com"}` and update
+  // the code so links no longer carry the /tasks-sse prefix.
+  "env": {
+    "production": {
+      "routes": [
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/tasks-sse", "custom_domain": false },
+        { "zone_name": "parallel.ai", "pattern": "oss.parallel.ai/tasks-sse/*", "custom_domain": false }
+      ]
     }
-  ]
+  }
 }

--- a/website/cookbook.json
+++ b/website/cookbook.json
@@ -1,94 +1,222 @@
 {
-  "drafts": [
-    {
-      "slug": "parallel-csv",
-      "popular": false,
-      "featured": false,
-      "title": "Ingest to batch tasks",
-      "description": "Using Parallel Ingest and Task Group API for efficient CSV processing and batch operations",
-      "repoUrl": "https://github.com/janwilmake/parallel-csv",
-      "websiteUrl": "https://csv.p0web.com",
-      "creators": ["janwilmake"],
-      "imageUrl": null,
-      "tags": ["ingest", "batch", "csv"]
-    },
-
-    {
-      "slug": "universal-mcp-oauth",
-      "popular": false,
-      "featured": true,
-      "title": "Tasks using MCP",
-      "description": "X Login, authorize MCPs, and execute tasks using Model Context Protocol integration",
-      "repoUrl": "https://github.com/janwilmake/universal-mcp-oauth/tree/main/examples/parallel-tool-calling",
-      "websiteUrl": "https://mcp.p0web.com",
-      "creators": ["janwilmake"],
-      "imageUrl": "http://svg.quickog.com/https://mcp.p0web.com/og.svg",
-      "tags": ["mcp", "oauth", "tasks"]
-    }
-  ],
+  "drafts": [],
 
   "cookbooks": [
     {
-      "slug": "parallel-tasks-sse",
-      "popular": false,
+      "slug": "parallel-vercel-template",
+      "popular": true,
       "featured": true,
-      "title": "Tasks using SSE",
-      "description": "Real-time task execution with Server-Sent Events for live updates and progress tracking",
+      "title": "Vercel Template",
+      "description": "Next.js demo of Search, Extract, and Tasks with real-time SSE streaming. One-click deploy with Vercel marketplace integration.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-vercel-template",
+      "websiteUrl": "https://parallel-vercel-template-cookbook.vercel.app/",
+      "creators": ["parallel-web"],
+      "imageUrl": "https://assets.parallel.ai/cookbook/vercel_cookbook_picture.png",
+      "tags": ["template", "search", "extract", "task", "sse", "vercel", "nextjs"]
+    },
+    {
+      "slug": "parallel-tasks-sse",
+      "popular": true,
+      "featured": true,
+      "title": "Tasks Playground (SSE)",
+      "description": "Full-featured Task manager with real-time SSE events across every processor. OAuth 2.1 with PKCE and dynamic client registration.",
       "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-tasks-sse",
-      "websiteUrl": "https://sse.p0web.com",
+      "websiteUrl": "https://oss.parallel.ai/tasks-sse/",
       "creators": ["janwilmake"],
       "imageUrl": "http://svg.quickog.com/https://sse.p0web.com/og.svg",
-      "tags": ["realtime", "tasks", "sse"]
+      "tags": ["realtime", "task", "sse", "oauth", "cloudflare"]
+    },
+    {
+      "slug": "parallel-search-agent-cerebras",
+      "popular": true,
+      "featured": true,
+      "title": "Search Agent (Cerebras)",
+      "description": "Multi-turn web research agent on Cerebras (GPT-OSS / Qwen). Iterative multi-angle searches with the Vercel AI SDK.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-search-agent-cerebras",
+      "websiteUrl": "https://oss.parallel.ai/agent/",
+      "creators": ["janwilmake"],
+      "imageUrl": "https://svg.quickog.com/https://agent.p0web.com/og.svg",
+      "tags": ["agent", "search", "cloudflare", "typescript"]
+    },
+    {
+      "slug": "parallel-search-agent-groq",
+      "popular": false,
+      "featured": false,
+      "title": "Search Agent (Groq)",
+      "description": "Same agent architecture, Llama 4 Maverick on Groq with 128k context for long-running research sessions.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-search-agent-groq",
+      "websiteUrl": "https://oss.parallel.ai/agent/",
+      "creators": ["janwilmake"],
+      "imageUrl": null,
+      "tags": ["agent", "search", "cloudflare", "typescript"]
     },
     {
       "slug": "parallel-daily-insights",
-      "popular": false,
+      "popular": true,
       "featured": true,
-      "title": "Recurring Tasks and Webhooks",
-      "description": "Active monitoring using cron jobs and KV storage for scheduled tasks and webhook handling",
+      "title": "Daily Insights",
+      "description": "Cron-triggered daily research feed. Schedules Tasks, persists to KV, publishes a public data feed.",
       "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights",
       "websiteUrl": "https://daily.p0web.com",
       "creators": ["janwilmake"],
       "imageUrl": "http://svg.quickog.com/https://daily.p0web.com/og.svg",
-      "tags": ["cron", "webhooks", "monitoring"]
+      "tags": ["monitoring", "task", "webhooks", "cloudflare"]
     },
     {
-      "slug": "web-search-agent",
-      "popular": false,
+      "slug": "parallel-supabase-enrichment",
+      "popular": true,
       "featured": true,
-      "title": "Web Search Agent",
-      "description": "Using an AI agent for web search and information retrieval",
-      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-search-agent",
-      "websiteUrl": "https://agent.p0web.com",
-      "creators": ["janwilmake"],
-      "imageUrl": "https://svg.quickog.com/https://agent.p0web.com/og.svg",
-      "tags": ["agent", "search", "mcp"]
+      "title": "Supabase Enrichment",
+      "description": "Real-time enrichment pipeline. INSERT a row, an Edge Function fires a Task, results stream back via Supabase Realtime.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-supabase-enrichment",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-supabase-enrichment",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["enrichment", "task", "webhooks", "supabase", "nextjs"]
     },
-
     {
-      "slug": "parallel-spreadsheet",
+      "slug": "parallel-entity-resolution",
       "popular": false,
       "featured": false,
-      "title": "Parallel Spreadsheet",
-      "description": "Next.js project that provides AI-powered spreadsheet enrichment using Parallel AI for live web research",
-      "repoUrl": "https://github.com/zahidkhawaja/parallel-spreadsheet",
-      "websiteUrl": "https://github.com/zahidkhawaja/parallel-spreadsheet",
-      "creators": ["zahidkhawaja"],
+      "title": "Entity Resolution",
+      "description": "Find every social profile for a single person across platforms in one Task.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-entity-resolution",
+      "websiteUrl": "https://entity-resolution-demo.parallel.ai",
+      "creators": ["janwilmake"],
       "imageUrl": null,
-      "tags": ["nextjs", "typescript", "spreadsheet"]
+      "tags": ["entity-resolution", "task", "oauth", "cloudflare"]
     },
-
+    {
+      "slug": "parallel-fact-checker-cerebras",
+      "popular": false,
+      "featured": false,
+      "title": "Fact Checker (Cerebras)",
+      "description": "Extract claims from a passage, run Search per claim, stream verdicts in real time.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-fact-checker-cerebras",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-fact-checker-cerebras",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["fact-checking", "search", "extract", "cloudflare"]
+    },
+    {
+      "slug": "market-analysis-demo",
+      "popular": true,
+      "featured": false,
+      "title": "Market Analysis Demo",
+      "description": "Flask app that turns a market-research prompt into a streamed report with email delivery. SSE progress and webhook completion.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/python-recipes/market-analysis-demo",
+      "websiteUrl": "https://market-analysis-demo.parallel.ai/",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["deep-research", "task", "sse", "webhooks", "python"]
+    },
+    {
+      "slug": "vertex-ai-grounding",
+      "popular": false,
+      "featured": false,
+      "title": "Vertex AI Grounding",
+      "description": "Ground Gemini on Vertex AI with the Parallel Search API for current, cited responses. Marketplace and BYOK auth.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/python-recipes/vertex_ai_demo",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/python-recipes/vertex_ai_demo",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["search", "vertex-ai", "python"]
+    },
+    {
+      "slug": "competitive-analysis-demo",
+      "popular": false,
+      "featured": false,
+      "title": "Competitive Analysis",
+      "description": "Web Enrichment + Reddit MCP combined to produce competitive briefs.",
+      "repoUrl": "https://github.com/parallel-web/competitive-analysis-demo/tree/main",
+      "websiteUrl": "https://competitive-analysis-demo.parallel.ai/",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["task", "mcp", "python"]
+    },
+    {
+      "slug": "deep-research-notebook",
+      "popular": false,
+      "featured": false,
+      "title": "Deep Research Notebook",
+      "description": "Interactive Jupyter walkthrough of Deep Research — text and JSON outputs, citations, confidence scores, webhook patterns.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/blob/main/python-recipes/Deep_Research_Recipe.ipynb",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/blob/main/python-recipes/Deep_Research_Recipe.ipynb",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["deep-research", "task", "webhooks", "python", "notebook"]
+    },
+    {
+      "slug": "large-scale-tasks",
+      "popular": false,
+      "featured": false,
+      "title": "Large-Scale Tasks",
+      "description": "Production batch script for 1k+ row CSVs. Three-stage enqueue → fetch → merge with retry, dry-run, and idempotent state.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/blob/main/python-recipes/Large_Scale_Tasks_Recipe.py",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/blob/main/python-recipes/Large_Scale_Tasks_Recipe.py",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["batch", "task", "python"]
+    },
+    {
+      "slug": "task-group-temporal",
+      "popular": false,
+      "featured": false,
+      "title": "Task Groups + Temporal",
+      "description": "Combine Task Groups with Temporal workflow orchestration for enterprise-grade durability.",
+      "repoUrl": "https://github.com/parallel-web/parallel-cookbook/blob/main/python-recipes/Task_Group_Temporal_Recipe.py",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/blob/main/python-recipes/Task_Group_Temporal_Recipe.py",
+      "creators": ["parallel-web"],
+      "imageUrl": null,
+      "tags": ["task", "temporal", "python"]
+    },
+    {
+      "slug": "universal-mcp-oauth",
+      "popular": false,
+      "featured": false,
+      "title": "Tasks via MCP + OAuth",
+      "description": "X login, authorize MCPs, and execute Tasks using Model Context Protocol integration.",
+      "repoUrl": "https://github.com/janwilmake/universal-mcp-oauth/tree/main/examples/parallel-tool-calling",
+      "websiteUrl": "https://mcp.p0web.com",
+      "creators": ["janwilmake"],
+      "imageUrl": "http://svg.quickog.com/https://mcp.p0web.com/og.svg",
+      "tags": ["mcp", "oauth", "task"]
+    },
     {
       "slug": "basedpeople",
       "popular": false,
       "featured": false,
       "title": "Based People",
-      "description": "Never miss what tech leaders actually say",
+      "description": "Never miss what tech leaders actually say.",
       "repoUrl": "https://github.com/janwilmake/basedpeople",
       "websiteUrl": "https://basedpeople.com",
       "creators": ["janwilmake"],
       "imageUrl": null,
-      "tags": ["community", "workers", "typescript"]
+      "tags": ["monitoring", "cloudflare", "typescript"]
+    },
+    {
+      "slug": "parallel-spreadsheet",
+      "popular": false,
+      "featured": false,
+      "title": "Parallel Spreadsheet",
+      "description": "Next.js project that provides AI-powered spreadsheet enrichment using Parallel for live web research.",
+      "repoUrl": "https://github.com/zahidkhawaja/parallel-spreadsheet",
+      "websiteUrl": "https://github.com/zahidkhawaja/parallel-spreadsheet",
+      "creators": ["zahidkhawaja"],
+      "imageUrl": null,
+      "tags": ["enrichment", "nextjs", "typescript"]
+    },
+    {
+      "slug": "scira",
+      "popular": true,
+      "featured": false,
+      "title": "Scira",
+      "description": "Open-source AI-powered search engine. 10k+ stars on GitHub, Parallel-powered.",
+      "repoUrl": "https://github.com/zaidmukaddam/scira",
+      "websiteUrl": "https://scira.ai",
+      "creators": ["zaidmukaddam"],
+      "imageUrl": null,
+      "tags": ["agent", "search", "nextjs", "vercel"]
     }
   ]
 }

--- a/website/cookbook.json
+++ b/website/cookbook.json
@@ -23,7 +23,7 @@
       "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-tasks-sse",
       "websiteUrl": "https://oss.parallel.ai/tasks-sse/",
       "creators": ["janwilmake"],
-      "imageUrl": "http://svg.quickog.com/https://sse.p0web.com/og.svg",
+      "imageUrl": null,
       "tags": ["realtime", "task", "sse", "oauth", "cloudflare"]
     },
     {
@@ -35,7 +35,7 @@
       "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-search-agent-cerebras",
       "websiteUrl": "https://oss.parallel.ai/agent/",
       "creators": ["janwilmake"],
-      "imageUrl": "https://svg.quickog.com/https://agent.p0web.com/og.svg",
+      "imageUrl": null,
       "tags": ["agent", "search", "cloudflare", "typescript"]
     },
     {
@@ -57,9 +57,9 @@
       "title": "Daily Insights",
       "description": "Cron-triggered daily research feed. Schedules Tasks, persists to KV, publishes a public data feed.",
       "repoUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights",
-      "websiteUrl": "https://daily.p0web.com",
+      "websiteUrl": "https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-daily-insights",
       "creators": ["janwilmake"],
-      "imageUrl": "http://svg.quickog.com/https://daily.p0web.com/og.svg",
+      "imageUrl": null,
       "tags": ["monitoring", "task", "webhooks", "cloudflare"]
     },
     {
@@ -177,9 +177,9 @@
       "title": "Tasks via MCP + OAuth",
       "description": "X login, authorize MCPs, and execute Tasks using Model Context Protocol integration.",
       "repoUrl": "https://github.com/janwilmake/universal-mcp-oauth/tree/main/examples/parallel-tool-calling",
-      "websiteUrl": "https://mcp.p0web.com",
+      "websiteUrl": "https://github.com/janwilmake/universal-mcp-oauth/tree/main/examples/parallel-tool-calling",
       "creators": ["janwilmake"],
-      "imageUrl": "http://svg.quickog.com/https://mcp.p0web.com/og.svg",
+      "imageUrl": null,
       "tags": ["mcp", "oauth", "task"]
     },
     {

--- a/website/cookbook.schema.json
+++ b/website/cookbook.schema.json
@@ -45,9 +45,9 @@
             }
           },
           "imageUrl": {
-            "type": "string",
+            "type": ["string", "null"],
             "format": "uri",
-            "description": "Preview image URL for the cookbook"
+            "description": "Preview image URL for the cookbook (null if no image is available)"
           },
           "tags": {
             "type": "array",

--- a/website/home.html
+++ b/website/home.html
@@ -9,26 +9,17 @@
         content="Full-stack app recipes and examples for the Parallel Web. Build powerful applications with Parallel APIs." />
     <meta name="robots" content="index, follow" />
 
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://p0web.com" />
+    <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Parallel Cookbook - Build powerful applications with Parallel APIs" />
     <meta property="og:description"
         content="Full-stack app recipes and examples for the Parallel Web. Build powerful applications with Parallel APIs." />
-    <meta property="og:image" content="https://quickog.com/screenshot/p0web.com" />
-    <meta property="og:image:alt"
-        content="Full-stack app recipes and examples for the Parallel Web. Build powerful applications with Parallel APIs." />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
 
-    <!-- Twitter Meta Tags -->
+    <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta property="twitter:domain" content="p0web.com" />
-    <meta property="twitter:url" content="https://p0web.com" />
     <meta name="twitter:title" content="Parallel Cookbook - Build powerful applications with Parallel APIs" />
     <meta name="twitter:description"
         content="Full-stack app recipes and examples for the Parallel Web. Build powerful applications with Parallel APIs." />
-    <meta name="twitter:image" content="https://quickog.com/screenshot/p0web.com" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -4,9 +4,5 @@
   "main": "worker.ts",
   "compatibility_date": "2025-07-14",
   "assets": { "directory": "./public" },
-  "observability": { "logs": { "enabled": true } },
-  "routes": [
-    { "custom_domain": true, "pattern": "p0web.com" },
-    { "custom_domain": true, "pattern": "www.p0web.com" }
-  ]
+  "observability": { "logs": { "enabled": true } }
 }


### PR DESCRIPTION
## Summary

The cookbook had drifted: 5 recipes in the README, 14 in the repo, and a one-line CONTRIBUTING that just said "talk to @ janwilmake." This PR brings the public surface in line with what's actually shipped and benchmarks it against Anthropic, OpenAI, Mistral, Groq, Together, and Vercel AI cookbooks.

- **`README.md`** rewritten — hero, ToC, quick start in TS + Python, 14 recipes grouped into 9 categories (Templates, Agents, Enrichment, Realtime, Scheduled, Deep Research, Identity, Fact Checking, Cloud Integrations), Vercel deploy button, API badges per row.
- **`CONTRIBUTING.md`** replaced with a real submission guide — criteria table, folder layout, README template, registration steps, controlled tag vocabulary, quality checklist.
- **`website/cookbook.json`** synced — every shipped recipe is registered (previously 6 of 14 were missing); drafts cleared; featured/popular flags curated; `cookbook.schema.json` updated to allow `null` `imageUrl` matching real data.
- **`parallel-daily-insights`** — repointed personal-fork GitHub icons in `home.html`, `feed.html`, and `SPEC.md` to the cookbook upstream.
- **Dead links pruned** — `parallel-csv` removed (repo 404, demo offline, verified with curl).
- **Stub folder** — `typescript-recipes/parallel-search-agent/README.md` is now a useful pointer to both Cerebras and Groq variants instead of a one-line redirect.
- **Author scratch refs** trimmed from a few internal `SPEC.md` files.

## Test plan

- [ ] README renders cleanly on github.com (tables, badges, ToC anchors)
- [ ] `npx ajv-cli validate -s website/cookbook.schema.json -d website/cookbook.json --strict=false` passes
- [ ] Visit https://p0web.com after deploy and confirm new entries appear with correct featured/popular grouping
- [ ] Click each "Code" and "Demo" link in the rendered README — all 200
- [ ] Spot-check one Cloudflare and one Vercel recipe still builds from a fresh clone using only its README