### PR TITLE
Add Datacenter Monitor recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Recurring research, cron jobs, and webhook delivery.
 | Recipe | Description | APIs | Stack | Demo |
 | --- | --- | --- | --- | --- |
 | [**Daily Insights**](typescript-recipes/parallel-daily-insights) | Cron-triggered daily research feed — runs Tasks on a schedule, persists to KV, publishes a public data feed. Includes a `SPEC.md` showing the task spec used. | `Task` `Webhooks` `Cron` | Cloudflare Workers · KV | – |
+| [**Datacenter Monitor**](https://github.com/khushishelat/datacenter-map-demo) | Live map of 2,800+ U.S. datacenters — discovered by iterative Task runs (shard-by-state + `previous_interaction_id` loop-until-dry), enriched with 25 cited fields via Task Groups, and watched by 31 event monitors + 200 daily snapshots with field-level diffs. | `Task` `Task Group` `Monitor` `Webhooks` `SSE` | Next.js · Vercel | [Live](https://datacenter-map-demo.vercel.app) |
 
 ### Deep Research & Notebooks
 

--- a/website/cookbook.json
+++ b/website/cookbook.json
@@ -229,6 +229,18 @@
       "creators": ["zaidmukaddam"],
       "imageUrl": null,
       "tags": ["agent", "search", "nextjs", "vercel"]
+    },
+    {
+      "slug": "datacenter-monitor",
+      "popular": false,
+      "featured": false,
+      "title": "Datacenter Monitor",
+      "description": "Live map of 2,800+ U.S. datacenters discovered, enriched, and monitored with the Task and Monitor APIs — every field traceable to its sources.",
+      "repoUrl": "https://github.com/khushishelat/datacenter-map-demo",
+      "websiteUrl": "https://datacenter-map-demo.vercel.app",
+      "creators": ["khushishelat"],
+      "imageUrl": null,
+      "tags": ["task", "monitoring", "enrichment", "webhooks", "sse", "nextjs", "vercel"]
     }
   ]
 }


### PR DESCRIPTION
Adds **Datacenter Monitor** — a live map of 2,800+ U.S. datacenters, discovered / enriched / monitored end-to-end on Parallel's Task and Monitor APIs.

- **Live demo:** https://datacenter-map-demo.vercel.app
- **Repo:** https://github.com/khushishelat/datacenter-map-demo

Submitting as an external/community-style recipe (like Competitive Analysis) — the app lives in its own repo, so this PR only registers it in the two required places:
- Row under **Scheduled Research & Webhooks** in `README.md`
- Entry in `website/cookbook.json` (validated against the schema)

### Why it's worth a spot
The distinctive, reusable technique is **iterative dataset discovery**: a single "find all US datacenters" Task plateaus ~50 results, so the app shards by state and paginates with `previous_interaction_id` (loop-until-dry) to enumerate ~2,800 facilities across the long tail. From there:
- 25-field enrichment per facility via **Task Groups**, with `output.basis` powering per-cell reasoning + citations
- an AI-impact classification pass (water / grid / community)
- **31 event-stream monitors** + **200 daily snapshot monitors** (field-level diffs, each with its own basis), delivered via webhooks + SSE
- a weekly brief written by the Task API, every claim linked to a source

The repo's README documents the full pipeline and includes the discovery script (`build_datacenters_iterative.py`).

### Checklist
- [x] Live demo reachable
- [x] No secrets committed (`.env.local.example` only; keys read from env)
- [x] LICENSE (MIT) in the source repo
- [x] Lockfile committed in the source repo
- [x] Registered in both `README.md` and `website/cookbook.json`
- [ ] `imageUrl` set to `null` for now — happy to add an OG image if preferred

Marked as **draft** — open to moving it to Community Examples or a different category, and to `creators`/repo-owner changes if you'd rather it live under `parallel-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)