### PR TITLE
Point brand asset URLs at assets.parallel.ai

### DIFF
--- a/python-recipes/market-analysis-demo/static/css/style.css
+++ b/python-recipes/market-analysis-demo/static/css/style.css
@@ -3,14 +3,14 @@
 /* Primary font stack - Monospace for body text */
 @font-face {
     font-family: 'FT System Mono';
-    src: url('https://assets.p0web.com/FTSystemMono-Regular.woff2') format('woff2');
+    src: url('https://assets.parallel.ai/FTSystemMono-Regular.woff2') format('woff2');
     font-weight: 400;
     font-display: swap;
 }
 
 @font-face {
     font-family: 'FT System Mono';
-    src: url('https://assets.p0web.com/FTSystemMono-Medium.woff2') format('woff2');
+    src: url('https://assets.parallel.ai/FTSystemMono-Medium.woff2') format('woff2');
     font-weight: 500;
     font-display: swap;
 }
@@ -18,14 +18,14 @@
 /* Display font for headings */
 @font-face {
     font-family: 'Gerstner Programm';
-    src: url('https://assets.p0web.com/Gerstner-ProgrammRegular.woff2') format('woff2');
+    src: url('https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2') format('woff2');
     font-weight: 400;
     font-display: swap;
 }
 
 @font-face {
     font-family: 'Gerstner Programm';
-    src: url('https://assets.p0web.com/Gerstner-ProgrammMedium.woff2') format('woff2');
+    src: url('https://assets.parallel.ai/Gerstner-ProgrammMedium.woff2') format('woff2');
     font-weight: 500;
     font-display: swap;
 }

--- a/python-recipes/parallel-investor-signals/project/src/brand/parallel-theme.css
+++ b/python-recipes/parallel-investor-signals/project/src/brand/parallel-theme.css
@@ -11,28 +11,28 @@
 
 @font-face {
   font-family: "Gerstner Programm";
-  src: url("https://assets.p0web.com/Gerstner-ProgrammRegular.woff2") format("woff2");
+  src: url("https://assets.parallel.ai/Gerstner-ProgrammRegular.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Gerstner Programm";
-  src: url("https://assets.p0web.com/Gerstner-ProgrammMedium.woff2") format("woff2");
+  src: url("https://assets.parallel.ai/Gerstner-ProgrammMedium.woff2") format("woff2");
   font-weight: 500;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "FT System Mono";
-  src: url("https://assets.p0web.com/FTSystemMono-Regular.woff2") format("woff2");
+  src: url("https://assets.parallel.ai/FTSystemMono-Regular.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "FT System Mono";
-  src: url("https://assets.p0web.com/FTSystemMono-Medium.woff2") format("woff2");
+  src: url("https://assets.parallel.ai/FTSystemMono-Medium.woff2") format("woff2");
   font-weight: 500;
   font-style: normal;
   font-display: swap;

--- a/typescript-recipes/parallel-daily-insights/public/og.svg
+++ b/typescript-recipes/parallel-daily-insights/public/og.svg
@@ -3,7 +3,7 @@
   <rect width="1200" height="630" fill="#fcfcfa"/>
   
   <!-- Parallel Icon -->
-  <image x="80" y="60" width="120" height="120" href="https://assets.p0web.com/dark-parallel-symbol-540.svg"/>
+  <image x="80" y="60" width="120" height="120" href="https://assets.parallel.ai/dark-parallel-symbol-540.svg"/>
   
   <!-- Main Title -->
   <text x="240" y="110" font-family="'FT System Mono', monospace" font-size="48" font-weight="600" fill="#1d1b16">

--- a/typescript-recipes/parallel-vercel-template/app/page.tsx
+++ b/typescript-recipes/parallel-vercel-template/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
           <div className="flex items-center justify-center gap-4 mb-4">
             {/* Parallel Logo (white) */}
             <img
-              src="https://assets.p0web.com/white-parallel-symbol-270.svg"
+              src="https://assets.parallel.ai/white-parallel-symbol-270.svg"
               alt="Parallel"
               className="w-10 h-10"
             />


### PR DESCRIPTION
Swaps all `assets.p0web.com` font/logo URLs for `assets.parallel.ai`, which serves byte-identical files (verified all six referenced assets return 200 with matching sizes on both hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)