### PR TITLE
Measure Search and inference usage in the Groq agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ LLM agents that use Parallel's Search API as a tool with the Vercel AI SDK.
 | Recipe | Description | APIs | Stack | Demo |
 | --- | --- | --- | --- | --- |
 | [**Search Agent (Cerebras)**](typescript-recipes/parallel-search-agent-cerebras) | Multi-turn web research agent backed by Cerebras (GPT-OSS / Qwen). Iterative multi-angle searches, full-stack with vanilla JS frontend. | `Search` | Cloudflare Workers · Cerebras · AI SDK | [Live](https://oss.parallel.ai/agent/) |
-| [**Search Agent (Groq)**](typescript-recipes/parallel-search-agent-groq) | Same agent shape, Llama 4 Maverick on Groq with 128k context for long sessions. | `Search` | Cloudflare Workers · Groq · AI SDK | [Live](https://oss.parallel.ai/agent/) |
+| [**Search Agent (Groq)**](typescript-recipes/parallel-search-agent-groq) | Llama 4 Maverick agent with measured Search latency, retrieved context, provider-reported tokens, and configurable cost estimates. | `Search` | Cloudflare Workers · Groq · AI SDK | [Live](https://oss.parallel.ai/agent/) |
 
 ### Data Enrichment
 

--- a/typescript-recipes/parallel-search-agent-groq/.env.example
+++ b/typescript-recipes/parallel-search-agent-groq/.env.example
@@ -1,2 +1,11 @@
 GROQ_API_KEY=
 PARALLEL_API_KEY=
+
+# GA Search mode: turbo, fast, basic, or advanced.
+PARALLEL_SEARCH_MODE=basic
+
+# Optional overrides. Leave blank to use published Search defaults or to
+# report model cost as unavailable until you provide your actual rates.
+PARALLEL_SEARCH_USD_PER_1K=
+MODEL_INPUT_USD_PER_1M=
+MODEL_OUTPUT_USD_PER_1M=

--- a/typescript-recipes/parallel-search-agent-groq/README.md
+++ b/typescript-recipes/parallel-search-agent-groq/README.md
@@ -2,7 +2,7 @@
 
 [![janwilmake/parallel-search-agent context](https://badge.forgithub.com/janwilmake/parallel-search-agent?lines=false)](https://uithub.com/janwilmake/parallel-search-agent?lines=false) [![](https://remix.forgithub.com/badge)](https://remix.forgithub.com/janwilmake/parallel-search-agent)
 
-This guide demonstrates how to build a web research agent that combines Parallel's Search API with streaming AI inference. By the end, you'll have a complete search agent with a simple frontend that shows searches, results, and AI responses as they stream in real-time.
+This guide demonstrates how to build a web research agent that combines Parallel's GA Search API with streaming AI inference. By the end, you'll have a complete search agent that shows searches, results, AI responses, measured retrieval and model usage, and clearly labeled cost estimates as they stream in real time.
 
 Complete app available at: https://oss.parallel.ai/agent/
 
@@ -14,6 +14,7 @@ The search agent we're building includes:
 - User-editable system prompt in config modal
 - Agent connection through Parallel Search API tool use
 - Streaming searches, search results, AI reasoning, and AI responses
+- Measured Search latency and context volume, provider-reported model tokens, and configurable cost assumptions
 - Clean rendering of results as they arrive
 
 Our technology stack:
@@ -50,15 +51,36 @@ Now that we understand the architectural advantages, let's walk through building
 ### Dependencies and Setup
 
 ```bash
-npm i ai zod @ai-sdk/groq
+cd typescript-recipes/parallel-search-agent-groq
+npm install
+cp .env.example .dev.vars
 ```
+
+Add your `PARALLEL_API_KEY` and `GROQ_API_KEY` to `.dev.vars`. Then run the deterministic economics tests and start the existing local worker:
+
+```bash
+npm test
+npm run dev
+```
+
+Open the Wrangler URL printed in your terminal, normally `http://localhost:8787`, or inspect the complete event stream directly:
+
+```bash
+curl -N http://localhost:8787/ \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What recent product changes should an AI developer know about Parallel Search?"}'
+```
+
+The final `finish` event includes an `economics` object. Each invocation makes real model and Search API calls, so latency, returned context, token usage, and estimated cost vary. The tests require no API keys, network access, or model calls.
 
 To prevent TypeScript's "Type instantiation is excessively deep" error, zod requires a version suffix. Import the required functions:
 
 ```typescript
+import Parallel from "parallel-web";
 import { createGroq } from "@ai-sdk/groq";
 import { streamText, tool, stepCountIs } from "ai";
 import { z } from "zod/v4";
+import { createEconomicsTracker, readEconomicsConfig } from "./economics";
 ```
 
 ### Defining the Search Tool
@@ -66,20 +88,27 @@ import { z } from "zod/v4";
 This section covers setting up the core search functionality that will power our AI agent:
 
 ```typescript
-//define execution of the tool
+const economicsConfig = readEconomicsConfig(env);
+const economics = createEconomicsTracker(economicsConfig);
+
 const execute = async ({ objective }) => {
   const parallel = new Parallel({
     apiKey: env.PARALLEL_API_KEY,
   });
 
-  const searchResult = await parallel.beta.search({
+  const startedAt = performance.now();
+  const searchResult = await parallel.search({
     objective,
-    search_queries: undefined,
-    processor: "base",
-    // Keep reasonable to balance context and token usage
-    max_results: 10,
-    max_chars_per_result: 1000,
+    search_queries: [objective],
+    mode: economicsConfig.searchMode,
+    max_chars_total: 25_000,
+    advanced_settings: {
+      max_results: 10,
+      excerpt_settings: { max_chars_per_result: 2_500 },
+    },
   });
+
+  economics.recordSearch(searchResult, performance.now() - startedAt);
   return searchResult;
 };
 
@@ -99,6 +128,7 @@ const searchTool = tool({
   inputSchema: z.object({
     objective: z
       .string()
+      .max(200)
       .describe(
         "Natural-language description of your research goal (max 200 characters)"
       ),
@@ -109,9 +139,9 @@ const searchTool = tool({
 
 ### Key implementation choices:
 
-- We choose "objective" over "search_queries" because it allows for natural language description of research goals, making the tool more intuitive for the AI to use
-- The "base" processor prioritizes speed while "pro" focuses on freshness and quality - choose based on your use case requirements
-- Token limits are balanced to provide sufficient context without overwhelming the model
+- The model writes a natural-language objective, and the Search tool also supplies it as the nonempty `search_queries` array required by GA Search.
+- `basic` preserves the closest GA equivalent to the legacy one-shot integration. Set `PARALLEL_SEARCH_MODE=turbo`, `fast`, `basic`, or `advanced` to compare modes on your own workload.
+- The existing limit of ten sources with at most 2,500 excerpt characters each remains in place. Character and byte measurements describe retrieved context, not tokenizer output.
 
 ## Creating the Streaming Agent
 
@@ -157,12 +187,41 @@ The `stepCountIs(25)` parameter allows the agent to make multiple search calls a
 
 The system prompt guides the agent to conduct multiple searches from different perspectives, which is crucial for comprehensive research.
 
-`.env`
+`.dev.vars`
 
 ```bash
 GROQ_API_KEY=YOUR_KEY
 PARALLEL_API_KEY=YOUR_KEY
+PARALLEL_SEARCH_MODE=basic
 ```
+
+## Measure the actual integration economics
+
+Every completed agent response reports:
+
+- **Measured:** successful Search calls, Search mode, per-call and aggregate client-side Search latency, returned source and excerpt counts, Unicode excerpt characters, serialized tool-result bytes, and total wall-clock workflow duration.
+- **Provider-reported:** aggregated model input, output, and total token counts from the AI SDK's final `totalUsage` event. A missing count remains `null`; excerpt characters and bytes are never presented as tokens.
+- **Assumed and estimated:** Search and model costs derived from your configured per-unit rates. The total remains `null` until both model rates and actual input/output token counts are available.
+
+Search prices default to the [published Parallel pricing](https://docs.parallel.ai/getting-started/pricing): `turbo` and `fast` are `$1 / 1,000 requests`, while `basic` and `advanced` are `$5 / 1,000 requests`, each including ten results. These defaults are pricing assumptions, not billing receipts. Verify current pricing and override them if your plan differs:
+
+```bash
+# Example configuration only. Replace the model rates with your actual plan.
+PARALLEL_SEARCH_MODE=turbo
+PARALLEL_SEARCH_USD_PER_1K=1
+MODEL_INPUT_USD_PER_1M=YOUR_INPUT_PRICE_PER_MILLION
+MODEL_OUTPUT_USD_PER_1M=YOUR_OUTPUT_PRICE_PER_MILLION
+```
+
+The estimate uses `search calls × Search price / 1,000` and `(input tokens × input price + output tokens × output price) / 1,000,000`. This recipe requests at most the ten results included in the published Search price. It does not estimate cache discounts, reasoning-specific token rates, taxes, provider credits, unsuccessful requests, or contractual discounts. No benchmark, competitor comparison, or representative latency is implied: run the workflow with your own keys and inputs to collect real measurements.
+
+For a credential-free, reproducible check of Unicode context measurement, multi-call aggregation, GA mode pricing, missing provider usage, invalid configuration, and model-cost arithmetic:
+
+```bash
+npm test
+```
+
+The fixture values in those tests are deterministic arithmetic examples, not live benchmark results.
 
 ## Streaming Response Handler
 
@@ -175,7 +234,11 @@ const stream = new ReadableStream({
   async start(controller) {
     try {
       for await (const chunk of result.fullStream) {
-        const data = `data: ${JSON.stringify(chunk)}\n\n`;
+        const event =
+          chunk.type === "finish"
+            ? { ...chunk, economics: economics.summarize(chunk.totalUsage) }
+            : chunk;
+        const data = `data: ${JSON.stringify(event)}\n\n`;
         controller.enqueue(encoder.encode(data));
       }
       controller.enqueue(encoder.encode("data: [DONE]\n\n"));
@@ -366,7 +429,7 @@ function handleStreamChunk(chunk) {
       break;
     case "finish":
       finalizeCurrentSection();
-      addFinishIndicator(chunk.finishReason);
+      addFinishIndicator(chunk.finishReason, chunk.economics);
       console.log("Research completed with reason:", chunk.finishReason);
       break;
   }
@@ -384,6 +447,8 @@ The complete source files provide essential context for both backend logic and f
 Essential source files:
 
 - `worker.ts` - Complete backend implementation
+- `economics.ts` - Measured retrieval, provider usage, and explicit pricing assumptions
+- `economics.test.mjs` - Deterministic, credential-free regression coverage
 - `index.html` - Frontend with streaming UI
 
 These files contain the complete TypeScript definitions and HTML implementation that are essential for understanding the full integration between the Parallel Search API and the streaming frontend.
@@ -401,7 +466,7 @@ The guide uses Llama 4 Maverick 17B on Groq, which provides excellent speed and 
 This demonstration omits several production requirements:
 Authentication: No user authentication is implemented
 
-- Rate limiting: Currently limited only by API budgets
+- Rate limiting: Uses the configured Cloudflare KV namespace; configure your own namespace for deployment
 - Error handling: Basic error handling is shown but could be expanded
 - Monitoring: No observability or logging beyond basic console output
 
@@ -413,4 +478,6 @@ Resources:
 
 - [Complete source code](https://github.com/parallel-web/parallel-cookbook/tree/main/typescript-recipes/parallel-search-agent)
 - [Parallel API documentation](https://docs.parallel.ai/)
+- [Search migration guide](https://docs.parallel.ai/search/search-migration-guide)
+- [Current Search pricing](https://docs.parallel.ai/getting-started/pricing)
 - [Get Parallel API keys](https://platform.parallel.ai/)

--- a/typescript-recipes/parallel-search-agent-groq/README.md
+++ b/typescript-recipes/parallel-search-agent-groq/README.md
@@ -200,7 +200,7 @@ PARALLEL_SEARCH_MODE=basic
 Every completed agent response reports:
 
 - **Measured:** successful Search calls, Search mode, per-call and aggregate client-side Search latency, returned source and excerpt counts, Unicode excerpt characters, serialized tool-result bytes, and total wall-clock workflow duration.
-- **Provider-reported:** aggregated model input, output, and total token counts from the AI SDK's final `totalUsage` event. A missing count remains `null`; excerpt characters and bytes are never presented as tokens.
+- **Provider-reported:** model input, output, and total token counts summed across the AI SDK's `finish-step` events. If any step omits a count, that workflow count remains `null` instead of reporting a partial sum. Excerpt characters and bytes are never presented as tokens.
 - **Assumed and estimated:** Search and model costs derived from your configured per-unit rates. The total remains `null` until both model rates and actual input/output token counts are available.
 
 Search prices default to the [published Parallel pricing](https://docs.parallel.ai/getting-started/pricing): `turbo` and `fast` are `$1 / 1,000 requests`, while `basic` and `advanced` are `$5 / 1,000 requests`, each including ten results. These defaults are pricing assumptions, not billing receipts. Verify current pricing and override them if your plan differs:
@@ -234,9 +234,12 @@ const stream = new ReadableStream({
   async start(controller) {
     try {
       for await (const chunk of result.fullStream) {
+        if (chunk.type === "finish-step") {
+          economics.recordModelUsage(chunk.usage);
+        }
         const event =
           chunk.type === "finish"
-            ? { ...chunk, economics: economics.summarize(chunk.totalUsage) }
+            ? { ...chunk, economics: economics.summarize() }
             : chunk;
         const data = `data: ${JSON.stringify(event)}\n\n`;
         controller.enqueue(encoder.encode(data));

--- a/typescript-recipes/parallel-search-agent-groq/economics.test.mjs
+++ b/typescript-recipes/parallel-search-agent-groq/economics.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import ts from "typescript";
+
+const { outputText } = ts.transpileModule(
+  readFileSync(new URL("./economics.ts", import.meta.url), "utf8"),
+  { compilerOptions: { module: ts.ModuleKind.ESNext } }
+);
+const { createEconomicsTracker, readEconomicsConfig } = await import(
+  `data:text/javascript,${encodeURIComponent(outputText)}`
+);
+
+test("GA search modes use their documented, overridable pricing assumptions", () => {
+  for (const [mode, price] of [
+    ["turbo", 1],
+    ["fast", 1],
+    ["basic", 5],
+    ["advanced", 5],
+  ]) {
+    assert.equal(
+      readEconomicsConfig({ PARALLEL_SEARCH_MODE: mode }).searchUsdPer1k,
+      price
+    );
+  }
+
+  const overridden = readEconomicsConfig({
+    PARALLEL_SEARCH_USD_PER_1K: "2.25",
+    MODEL_INPUT_USD_PER_1M: "0",
+    MODEL_OUTPUT_USD_PER_1M: "1.50",
+  });
+
+  assert.deepEqual(overridden, {
+    searchMode: "basic",
+    searchUsdPer1k: 2.25,
+    modelInputUsdPer1m: 0,
+    modelOutputUsdPer1m: 1.5,
+  });
+});
+
+test("invalid modes and pricing fail without silently misreporting costs", () => {
+  assert.throws(
+    () => readEconomicsConfig({ PARALLEL_SEARCH_MODE: "one-shot" }),
+    /PARALLEL_SEARCH_MODE/
+  );
+
+  for (const invalidPrice of ["-1", "NaN", "Infinity"]) {
+    assert.throws(
+      () =>
+        readEconomicsConfig({ PARALLEL_SEARCH_USD_PER_1K: invalidPrice }),
+      /non-negative, finite number/
+    );
+  }
+});
+
+test("reports measured retrieval, provider token usage, and configured costs", () => {
+  let now = 1_000;
+  const tracker = createEconomicsTracker(
+    readEconomicsConfig({
+      PARALLEL_SEARCH_MODE: "turbo",
+      MODEL_INPUT_USD_PER_1M: "2",
+      MODEL_OUTPUT_USD_PER_1M: "8",
+    }),
+    () => now
+  );
+  const firstSearch = {
+    search_id: "fixture-search-1",
+    results: [
+      { url: "https://example.com/one", excerpts: ["hello", "🌍"] },
+      { url: "https://example.com/two", excerpts: [] },
+    ],
+  };
+  const secondSearch = {
+    search_id: "fixture-search-2",
+    results: [{ url: "https://example.com/three", excerpts: ["context"] }],
+  };
+
+  tracker.recordSearch(firstSearch, 120.4);
+  tracker.recordSearch(secondSearch, 79.6);
+  now = 1_450;
+
+  assert.deepEqual(
+    tracker.summarize({
+      inputTokens: 1_200,
+      outputTokens: 300,
+      totalTokens: 1_500,
+    }),
+    {
+      search: {
+        mode: "turbo",
+        calls: 2,
+        sources: 3,
+        excerpts: 3,
+        excerptCharacters: 13,
+        serializedResultBytes:
+          new TextEncoder().encode(JSON.stringify(firstSearch)).length +
+          new TextEncoder().encode(JSON.stringify(secondSearch)).length,
+        latenciesMs: [120, 80],
+        totalLatencyMs: 200,
+        assumedUsdPer1k: 1,
+        estimatedCostUsd: 0.002,
+      },
+      inference: {
+        inputTokens: 1_200,
+        outputTokens: 300,
+        totalTokens: 1_500,
+        assumedInputUsdPer1m: 2,
+        assumedOutputUsdPer1m: 8,
+        estimatedCostUsd: 0.0048,
+      },
+      workflow: {
+        elapsedMs: 450,
+        estimatedTotalCostUsd: 0.0068,
+      },
+    }
+  );
+});
+
+test("leaves unavailable usage and model pricing explicitly unavailable", () => {
+  const tracker = createEconomicsTracker(readEconomicsConfig({}), () => 25);
+  tracker.recordSearch({ results: [{ excerpts: null }] }, 0);
+
+  assert.deepEqual(tracker.summarize(), {
+    search: {
+      mode: "basic",
+      calls: 1,
+      sources: 1,
+      excerpts: 0,
+      excerptCharacters: 0,
+      serializedResultBytes: new TextEncoder().encode(
+        JSON.stringify({ results: [{ excerpts: null }] })
+      ).length,
+      latenciesMs: [0],
+      totalLatencyMs: 0,
+      assumedUsdPer1k: 5,
+      estimatedCostUsd: 0.005,
+    },
+    inference: {
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: null,
+      assumedInputUsdPer1m: null,
+      assumedOutputUsdPer1m: null,
+      estimatedCostUsd: null,
+    },
+    workflow: {
+      elapsedMs: 0,
+      estimatedTotalCostUsd: null,
+    },
+  });
+});
+
+test("rejects impossible search timings and unavailable provider token counts", () => {
+  const tracker = createEconomicsTracker(
+    readEconomicsConfig({
+      MODEL_INPUT_USD_PER_1M: "1",
+      MODEL_OUTPUT_USD_PER_1M: "1",
+    }),
+    () => 0
+  );
+
+  assert.throws(
+    () => tracker.recordSearch({ results: [] }, -1),
+    /Search latency/
+  );
+
+  const result = tracker.summarize({
+    inputTokens: -1,
+    outputTokens: 10,
+    totalTokens: Number.NaN,
+  });
+
+  assert.equal(result.inference.inputTokens, null);
+  assert.equal(result.inference.totalTokens, null);
+  assert.equal(result.inference.estimatedCostUsd, null);
+});

--- a/typescript-recipes/parallel-search-agent-groq/economics.test.mjs
+++ b/typescript-recipes/parallel-search-agent-groq/economics.test.mjs
@@ -1,16 +1,42 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import test from "node:test";
+import { runInThisContext } from "node:vm";
 
 import ts from "typescript";
 
-const { outputText } = ts.transpileModule(
-  readFileSync(new URL("./economics.ts", import.meta.url), "utf8"),
-  { compilerOptions: { module: ts.ModuleKind.ESNext } }
+const require = createRequire(import.meta.url);
+
+// Load the actual Worker and SDKs without changing the package's module mode
+// or depending on Node's version-specific TypeScript support.
+function loadTypeScript(url) {
+  const { outputText } = ts.transpileModule(readFileSync(url, "utf8"), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+    },
+  });
+  const module = { exports: {} };
+  runInThisContext(`(function(require, module, exports) { ${outputText}\n})`, {
+    filename: url.pathname,
+  })(
+    (id) => {
+      if (id.endsWith(".html")) return readFileSync(new URL(id, url), "utf8");
+      if (id.startsWith("./")) return loadTypeScript(new URL(`${id}.ts`, url));
+      return require(id);
+    },
+    module,
+    module.exports
+  );
+  return module.exports;
+}
+
+const { createEconomicsTracker, readEconomicsConfig } = loadTypeScript(
+  new URL("./economics.ts", import.meta.url)
 );
-const { createEconomicsTracker, readEconomicsConfig } = await import(
-  `data:text/javascript,${encodeURIComponent(outputText)}`
-);
+const worker = loadTypeScript(new URL("./worker.ts", import.meta.url)).default;
 
 test("GA search modes use their documented, overridable pricing assumptions", () => {
   for (const [mode, price] of [
@@ -78,14 +104,15 @@ test("reports measured retrieval, provider token usage, and configured costs", (
 
   tracker.recordSearch(firstSearch, 120.4);
   tracker.recordSearch(secondSearch, 79.6);
+  tracker.recordModelUsage({
+    inputTokens: 1_200,
+    outputTokens: 300,
+    totalTokens: 1_500,
+  });
   now = 1_450;
 
   assert.deepEqual(
-    tracker.summarize({
-      inputTokens: 1_200,
-      outputTokens: 300,
-      totalTokens: 1_500,
-    }),
+    tracker.summarize(),
     {
       search: {
         mode: "turbo",
@@ -165,13 +192,115 @@ test("rejects impossible search timings and unavailable provider token counts", 
     /Search latency/
   );
 
-  const result = tracker.summarize({
+  tracker.recordModelUsage({
     inputTokens: -1,
     outputTokens: 10,
     totalTokens: Number.NaN,
   });
+  const result = tracker.summarize();
 
   assert.equal(result.inference.inputTokens, null);
   assert.equal(result.inference.totalTokens, null);
   assert.equal(result.inference.estimatedCostUsd, null);
+});
+
+test("missing counts stay unavailable across steps without discarding known counts", () => {
+  for (const missingKey of ["inputTokens", "outputTokens", "totalTokens"]) {
+    for (const missingFirst of [true, false]) {
+      const tracker = createEconomicsTracker(readEconomicsConfig({}));
+      const complete = { inputTokens: 10, outputTokens: 0, totalTokens: 10 };
+      const partial = { ...complete, [missingKey]: undefined };
+      for (const usage of missingFirst ? [partial, complete] : [complete, partial]) {
+        tracker.recordModelUsage(usage);
+      }
+      const { inference } = tracker.summarize();
+      for (const key of Object.keys(complete)) {
+        assert.equal(inference[key], key === missingKey ? null : complete[key] * 2);
+      }
+    }
+  }
+});
+
+test("Worker streams real SDK tool calls and only estimates complete model usage", async (t) => {
+  const usage = { prompt_tokens: 200, completion_tokens: 20, total_tokens: 220 };
+  for (const scenario of [
+    { name: "complete usage", usages: [usage, usage], known: true },
+    { name: "first step missing", usages: [undefined, usage], known: false },
+    { name: "last step missing", usages: [usage, undefined], known: false },
+    { name: "Search failure", usages: [usage, usage], known: true, searchFails: true },
+  ]) {
+    await t.test(scenario.name, async (t) => {
+      let modelCalls = 0;
+      const searchRequests = [];
+      t.mock.method(globalThis, "fetch", async (url, options) => {
+        const target = String(url);
+        if (target === "https://api.parallel.ai/v1/search") {
+          searchRequests.push(JSON.parse(options.body));
+          return Response.json(
+            scenario.searchFails
+              ? { error: "Fixture Search failure" }
+              : { search_id: "fixture", session_id: "fixture", results: [
+                  { url: "https://example.com", title: "Fixture", excerpts: ["hello 🌍"] },
+                ] },
+            { status: scenario.searchFails ? 400 : 200 }
+          );
+        }
+        assert.equal(target, "https://api.groq.com/openai/v1/chat/completions");
+        assert.ok(modelCalls < 2, "Unexpected extra model request");
+        const first = modelCalls === 0;
+        const stepUsage = scenario.usages[modelCalls++];
+        const chunk = {
+          id: "fixture",
+          choices: [{
+            index: 0,
+            delta: first
+              ? { tool_calls: [{
+                  index: 0, id: "fixture-search", type: "function",
+                  function: { name: "search", arguments: JSON.stringify({ objective: "Parallel Search" }) },
+                }] }
+              : { content: "Fixture answer" },
+            finish_reason: first ? "tool_calls" : "stop",
+          }],
+          ...(stepUsage ? { x_groq: { usage: stepUsage } } : {}),
+        };
+        return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      });
+      const response = await worker.fetch(
+        new Request("http://localhost/", {
+          method: "POST", body: JSON.stringify({ query: "fixture" }),
+        }),
+        {
+          PARALLEL_API_KEY: "fixture", GROQ_API_KEY: "fixture",
+          PARALLEL_SEARCH_MODE: "turbo",
+          MODEL_INPUT_USD_PER_1M: "2", MODEL_OUTPUT_USD_PER_1M: "8",
+          RATE_LIMIT_KV: { get: async () => null, put: async () => {} },
+        },
+        {}
+      );
+      assert.equal(response.headers.get("Content-Type"), "text/event-stream");
+      const stream = await response.text();
+      assert.ok(stream.endsWith("data: [DONE]\n\n"));
+      const events = stream.split("\n\n").filter((line) => line && line !== "data: [DONE]")
+        .map((line) => JSON.parse(line.slice(6)));
+      assert.equal(modelCalls, 2);
+      assert.deepEqual(searchRequests, [{
+        objective: "Parallel Search", search_queries: ["Parallel Search"], mode: "turbo",
+        max_chars_total: 25_000,
+        advanced_settings: { max_results: 10, excerpt_settings: { max_chars_per_result: 2_500 } },
+      }]);
+      assert.ok(events.some((event) => event.type === (scenario.searchFails ? "tool-error" : "tool-result")));
+      assert.equal(events.find((event) => event.type === "text-delta").text, "Fixture answer");
+      const { economics } = events.find((event) => event.type === "finish");
+      assert.equal(economics.search.calls, scenario.searchFails ? 0 : 1);
+      assert.equal(economics.search.excerptCharacters, scenario.searchFails ? 0 : 7);
+      assert.equal(economics.inference.inputTokens, scenario.known ? 400 : null);
+      assert.equal(economics.inference.outputTokens, scenario.known ? 40 : null);
+      assert.equal(economics.inference.totalTokens, scenario.known ? 440 : null);
+      assert.equal(economics.inference.estimatedCostUsd, scenario.known ? 0.00112 : null);
+      assert.equal(economics.workflow.estimatedTotalCostUsd,
+        scenario.known ? (scenario.searchFails ? 0.00112 : 0.00212) : null);
+    });
+  }
 });

--- a/typescript-recipes/parallel-search-agent-groq/economics.ts
+++ b/typescript-recipes/parallel-search-agent-groq/economics.ts
@@ -1,0 +1,167 @@
+export type SearchMode = "turbo" | "fast" | "basic" | "advanced";
+
+const DEFAULT_SEARCH_PRICES_USD_PER_1K: Record<SearchMode, number> = {
+  turbo: 1,
+  fast: 1,
+  basic: 5,
+  advanced: 5,
+};
+
+interface EconomicsEnvironment {
+  PARALLEL_SEARCH_MODE?: string;
+  PARALLEL_SEARCH_USD_PER_1K?: string;
+  MODEL_INPUT_USD_PER_1M?: string;
+  MODEL_OUTPUT_USD_PER_1M?: string;
+}
+
+export interface EconomicsConfig {
+  searchMode: SearchMode;
+  searchUsdPer1k: number;
+  modelInputUsdPer1m: number | null;
+  modelOutputUsdPer1m: number | null;
+}
+
+interface SearchResult {
+  results: Array<{ excerpts?: string[] | null }>;
+}
+
+interface ModelUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+function readOptionalPrice(value: string | undefined, name: string) {
+  if (value === undefined || value.trim() === "") return null;
+
+  const price = Number(value);
+  if (!Number.isFinite(price) || price < 0) {
+    throw new Error(`${name} must be a non-negative, finite number`);
+  }
+
+  return price;
+}
+
+function roundUsd(amount: number) {
+  return Math.round(amount * 1_000_000_000) / 1_000_000_000;
+}
+
+function readTokenCount(count: number | undefined) {
+  return typeof count === "number" && Number.isSafeInteger(count) && count >= 0
+    ? count
+    : null;
+}
+
+export function readEconomicsConfig(env: EconomicsEnvironment): EconomicsConfig {
+  const searchMode = env.PARALLEL_SEARCH_MODE?.trim() || "basic";
+  if (!Object.hasOwn(DEFAULT_SEARCH_PRICES_USD_PER_1K, searchMode)) {
+    throw new Error(
+      "PARALLEL_SEARCH_MODE must be turbo, fast, basic, or advanced"
+    );
+  }
+
+  const mode = searchMode as SearchMode;
+
+  return {
+    searchMode: mode,
+    searchUsdPer1k:
+      readOptionalPrice(
+        env.PARALLEL_SEARCH_USD_PER_1K,
+        "PARALLEL_SEARCH_USD_PER_1K"
+      ) ?? DEFAULT_SEARCH_PRICES_USD_PER_1K[mode],
+    modelInputUsdPer1m: readOptionalPrice(
+      env.MODEL_INPUT_USD_PER_1M,
+      "MODEL_INPUT_USD_PER_1M"
+    ),
+    modelOutputUsdPer1m: readOptionalPrice(
+      env.MODEL_OUTPUT_USD_PER_1M,
+      "MODEL_OUTPUT_USD_PER_1M"
+    ),
+  };
+}
+
+/** Tracks observed retrieval and provider-reported inference without estimating tokens. */
+export function createEconomicsTracker(
+  config: EconomicsConfig,
+  now: () => number = () => performance.now()
+) {
+  const startedAt = now();
+  const encoder = new TextEncoder();
+  const searchLatenciesMs: number[] = [];
+  let sourceCount = 0;
+  let excerptCount = 0;
+  let excerptCharacters = 0;
+  let serializedResultBytes = 0;
+
+  return {
+    recordSearch(searchResult: SearchResult, elapsedMs: number) {
+      if (!Number.isFinite(elapsedMs) || elapsedMs < 0) {
+        throw new Error("Search latency must be a non-negative, finite number");
+      }
+
+      searchLatenciesMs.push(Math.round(elapsedMs));
+      sourceCount += searchResult.results.length;
+      serializedResultBytes += encoder.encode(
+        JSON.stringify(searchResult)
+      ).length;
+
+      for (const result of searchResult.results) {
+        for (const excerpt of result.excerpts ?? []) {
+          excerptCount += 1;
+          excerptCharacters += Array.from(excerpt).length;
+        }
+      }
+    },
+
+    summarize(usage?: ModelUsage) {
+      const inputTokens = readTokenCount(usage?.inputTokens);
+      const outputTokens = readTokenCount(usage?.outputTokens);
+      const totalTokens = readTokenCount(usage?.totalTokens);
+      const searchCostUsd = roundUsd(
+        (searchLatenciesMs.length * config.searchUsdPer1k) / 1_000
+      );
+      const modelCostUsd =
+        inputTokens !== null &&
+        outputTokens !== null &&
+        config.modelInputUsdPer1m !== null &&
+        config.modelOutputUsdPer1m !== null
+          ? roundUsd(
+              (inputTokens * config.modelInputUsdPer1m +
+                outputTokens * config.modelOutputUsdPer1m) /
+                1_000_000
+            )
+          : null;
+
+      return {
+        search: {
+          mode: config.searchMode,
+          calls: searchLatenciesMs.length,
+          sources: sourceCount,
+          excerpts: excerptCount,
+          excerptCharacters,
+          serializedResultBytes,
+          latenciesMs: [...searchLatenciesMs],
+          totalLatencyMs: searchLatenciesMs.reduce(
+            (total, latency) => total + latency,
+            0
+          ),
+          assumedUsdPer1k: config.searchUsdPer1k,
+          estimatedCostUsd: searchCostUsd,
+        },
+        inference: {
+          inputTokens,
+          outputTokens,
+          totalTokens,
+          assumedInputUsdPer1m: config.modelInputUsdPer1m,
+          assumedOutputUsdPer1m: config.modelOutputUsdPer1m,
+          estimatedCostUsd: modelCostUsd,
+        },
+        workflow: {
+          elapsedMs: Math.max(0, Math.round(now() - startedAt)),
+          estimatedTotalCostUsd:
+            modelCostUsd === null ? null : roundUsd(searchCostUsd + modelCostUsd),
+        },
+      };
+    },
+  };
+}

--- a/typescript-recipes/parallel-search-agent-groq/economics.ts
+++ b/typescript-recipes/parallel-search-agent-groq/economics.ts
@@ -92,8 +92,30 @@ export function createEconomicsTracker(
   let excerptCount = 0;
   let excerptCharacters = 0;
   let serializedResultBytes = 0;
+  let modelUsage: {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    totalTokens: number | null;
+  } | null = null;
 
   return {
+    recordModelUsage(usage?: ModelUsage) {
+      const totals = modelUsage ?? {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      };
+
+      // SDK totalUsage sums available counts, hiding steps with missing usage.
+      // A workflow count is known only when every model step reported it.
+      for (const key of ["inputTokens", "outputTokens", "totalTokens"] as const) {
+        const count = readTokenCount(usage?.[key]);
+        const total = totals[key];
+        totals[key] = total === null || count === null ? null : total + count;
+      }
+      modelUsage = totals;
+    },
+
     recordSearch(searchResult: SearchResult, elapsedMs: number) {
       if (!Number.isFinite(elapsedMs) || elapsedMs < 0) {
         throw new Error("Search latency must be a non-negative, finite number");
@@ -113,10 +135,10 @@ export function createEconomicsTracker(
       }
     },
 
-    summarize(usage?: ModelUsage) {
-      const inputTokens = readTokenCount(usage?.inputTokens);
-      const outputTokens = readTokenCount(usage?.outputTokens);
-      const totalTokens = readTokenCount(usage?.totalTokens);
+    summarize() {
+      const inputTokens = modelUsage?.inputTokens ?? null;
+      const outputTokens = modelUsage?.outputTokens ?? null;
+      const totalTokens = modelUsage?.totalTokens ?? null;
       const searchCostUsd = roundUsd(
         (searchLatenciesMs.length * config.searchUsdPer1k) / 1_000
       );

--- a/typescript-recipes/parallel-search-agent-groq/index.html
+++ b/typescript-recipes/parallel-search-agent-groq/index.html
@@ -752,7 +752,7 @@
                 case 'finish':
                     finalizeCurrentSection();
                     removeLoadingIndicator();
-                    addFinishIndicator(chunk.finishReason);
+                    addFinishIndicator(chunk.finishReason, chunk.economics);
                     console.log('Research completed with reason:', chunk.finishReason);
                     break;
             }
@@ -987,7 +987,7 @@
             return div.innerHTML;
         }
 
-        function addFinishIndicator(finishReason) {
+        function addFinishIndicator(finishReason, economics) {
             const finishElement = document.createElement('div');
             finishElement.className = 'finish-indicator p-4 sm:p-5 rounded mb-4 search-result';
 
@@ -1001,6 +1001,46 @@
                     <span class="ml-2 text-xs text-light-secondary">• ${reasonDisplay}</span>
                 </div>
             `;
+
+            if (economics) {
+                const details = document.createElement('dl');
+                details.className = 'mt-3 grid gap-2 text-xs sm:text-sm text-light-secondary';
+
+                const measuredTokens = economics.inference.inputTokens === null || economics.inference.outputTokens === null
+                    ? 'Unavailable from the model provider'
+                    : `${economics.inference.inputTokens.toLocaleString()} input / ${economics.inference.outputTokens.toLocaleString()} output`;
+                const modelCost = economics.inference.estimatedCostUsd === null
+                    ? 'Unavailable until model rates and token usage are provided'
+                    : `$${economics.inference.estimatedCostUsd.toFixed(6)}`;
+                const totalCost = economics.workflow.estimatedTotalCostUsd === null
+                    ? 'Unavailable until model rates and token usage are provided'
+                    : `$${economics.workflow.estimatedTotalCostUsd.toFixed(6)}`;
+                const rows = [
+                    ['Measured search calls', `${economics.search.calls} (${economics.search.mode})`],
+                    ['Measured search latency', `${economics.search.totalLatencyMs.toLocaleString()} ms across all calls`],
+                    ['Measured retrieved context', `${economics.search.excerptCharacters.toLocaleString()} excerpt characters; ${economics.search.serializedResultBytes.toLocaleString()} tool-result JSON bytes`],
+                    ['Provider-reported model tokens', measuredTokens],
+                    ['Estimated search cost', `$${economics.search.estimatedCostUsd.toFixed(6)} at $${economics.search.assumedUsdPer1k}/1,000 calls`],
+                    ['Estimated model cost', modelCost],
+                    ['Measured workflow duration', `${economics.workflow.elapsedMs.toLocaleString()} ms`],
+                    ['Estimated total cost', totalCost],
+                ];
+
+                for (const [label, value] of rows) {
+                    const row = document.createElement('div');
+                    const term = document.createElement('dt');
+                    const description = document.createElement('dd');
+
+                    row.className = 'flex flex-wrap justify-between gap-x-4';
+                    term.textContent = label;
+                    description.textContent = value;
+                    row.append(term, description);
+                    details.appendChild(row);
+                }
+
+                finishElement.appendChild(details);
+            }
+
             resultsContent.appendChild(finishElement);
         }
 

--- a/typescript-recipes/parallel-search-agent-groq/package.json
+++ b/typescript-recipes/parallel-search-agent-groq/package.json
@@ -3,12 +3,13 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "wrangler dev",
+    "test": "node --test economics.test.mjs",
     "deploy": "read -p \"Enter Cloudflare Account ID: \" account_id && CLOUDFLARE_ACCOUNT_ID=\"$account_id\" wrangler deploy"
   },
   "dependencies": {
     "@ai-sdk/groq": "^2.0.20",
     "ai": "^5.0.35",
-    "parallel-web": "^0.1.0",
+    "parallel-web": "^1.3.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/typescript-recipes/parallel-search-agent-groq/worker.ts
+++ b/typescript-recipes/parallel-search-agent-groq/worker.ts
@@ -167,11 +167,14 @@ IMPORTANT: Always start by using the search tool - do not provide answers withou
           async start(controller) {
             try {
               for await (const chunk of result.fullStream) {
+                if (chunk.type === "finish-step") {
+                  economics.recordModelUsage(chunk.usage);
+                }
                 const event =
                   chunk.type === "finish"
                     ? {
                         ...chunk,
-                        economics: economics.summarize(chunk.totalUsage),
+                        economics: economics.summarize(),
                       }
                     : chunk;
                 const data = `data: ${JSON.stringify(event)}\n\n`;

--- a/typescript-recipes/parallel-search-agent-groq/worker.ts
+++ b/typescript-recipes/parallel-search-agent-groq/worker.ts
@@ -1,8 +1,9 @@
 /// <reference types="@cloudflare/workers-types" />
-import { Parallel } from "parallel-web";
+import Parallel from "parallel-web";
 import { createGroq } from "@ai-sdk/groq";
 import { streamText, tool, stepCountIs } from "ai";
 import { z } from "zod/v4";
+import { createEconomicsTracker, readEconomicsConfig } from "./economics";
 import { rateLimitMiddleware } from "./ratelimit";
 //@ts-ignore
 import indexHtml from "./index.html";
@@ -11,6 +12,10 @@ export interface Env {
   PARALLEL_API_KEY: string;
   GROQ_API_KEY: string;
   RATE_LIMIT_KV: KVNamespace;
+  PARALLEL_SEARCH_MODE?: string;
+  PARALLEL_SEARCH_USD_PER_1K?: string;
+  MODEL_INPUT_USD_PER_1M?: string;
+  MODEL_OUTPUT_USD_PER_1M?: string;
 }
 
 function getClientIP(request: Request): string {
@@ -81,26 +86,27 @@ export default {
           return new Response("Query is required", { status: 400 });
         }
 
+        const economicsConfig = readEconomicsConfig(env);
+        const economics = createEconomicsTracker(economicsConfig);
+
         const execute = async ({ objective }) => {
           const parallel = new Parallel({
             apiKey: env.PARALLEL_API_KEY,
           });
 
-          const searchResult = await parallel.beta.search({
-            // Choose objective or search queries. We choose objective because it allows natural language way of describing what you're looking for
+          const searchStartedAt = performance.now();
+          const searchResult = await parallel.search({
             objective,
-            search_queries: undefined,
-            // "base" works best for apps where speed is important, while "pro" is better when freshness and content-quality is critical
-            processor: "base",
-
-            source_policy: {
-              exclude_domains: undefined,
-              include_domains: undefined,
+            search_queries: [objective],
+            mode: economicsConfig.searchMode,
+            max_chars_total: 25_000,
+            advanced_settings: {
+              max_results: 10,
+              excerpt_settings: { max_chars_per_result: 2_500 },
             },
-            max_results: 10,
-            // Keep low to save tokens
-            max_chars_per_result: 2500,
           });
+          economics.recordSearch(searchResult, performance.now() - searchStartedAt);
+
           return searchResult;
         };
 
@@ -120,6 +126,7 @@ export default {
           inputSchema: z.object({
             objective: z
               .string()
+              .max(200)
               .describe(
                 "Natural-language description of your research goal (max 200 characters)"
               ),
@@ -160,7 +167,14 @@ IMPORTANT: Always start by using the search tool - do not provide answers withou
           async start(controller) {
             try {
               for await (const chunk of result.fullStream) {
-                const data = `data: ${JSON.stringify(chunk)}\n\n`;
+                const event =
+                  chunk.type === "finish"
+                    ? {
+                        ...chunk,
+                        economics: economics.summarize(chunk.totalUsage),
+                      }
+                    : chunk;
+                const data = `data: ${JSON.stringify(event)}\n\n`;
                 controller.enqueue(encoder.encode(data));
               }
               controller.enqueue(encoder.encode("data: [DONE]\n\n"));


### PR DESCRIPTION
Our Groq agent shows searches and answers, but it doesn't show how much retrieval and model work a run uses. We add that information to the existing stream and UI so developers can inspect their own runs without a separate benchmark harness.

We move the tool from beta Search to GA Search, keep `basic` as the default, and make the Search mode and price assumptions configurable. A small tracker measures successful Search calls, latency, sources, excerpt characters and result bytes, then adds provider-reported model tokens and elapsed time to the final event. If a model step omits a token count, we leave that count unavailable for the whole run instead of showing a partial total.

We label dollar amounts as estimates, not measured spend. Characters and bytes are not tokens, and model and total cost stay unavailable until both model rates and complete input/output usage are present. The estimates exclude failed requests, cache or reasoning-specific rates, taxes, credits and discounts. They are not billing receipts or benchmark results.

**Testing:** Previously recorded validation includes five passing tests on Node 20, 22 and 24, strict economics-module and full Worker typechecks, and a Wrangler dry-run bundle without deployment. The current diff also adds tests for missing usage across steps and Worker streaming with mocked network responses. Recorded live validation covers one bounded Turbo Search request returning one result and one Search SKU, not a full live Groq run or deployment.

Tracking: [DEV-261](https://linear.app/parallelai/issue/DEV-261/show-developers-what-a-search-plus-model-run-actually-costs).
